### PR TITLE
Single-source model policy: drop hard-wired model versions (#98/#91/#66/#67)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ Verify both exist after `bcgasl` / `c-bpm-cm-library-pull`. If only one is popul
 
 ### Minimal hook example (issue-create guard)
 
+The issue-create guard is implemented as `my/hooks/issue-write-gate.ts` (built to `dist/issue-write-gate.mjs`) and registered by `install-hooks` on the `Bash`, `mcp__github__issue_write`, and `mcp__github__create_issue` matchers. A minimal single-matcher registration looks like:
+
 ```json
 {
   "hooks": {
@@ -122,7 +124,8 @@ Verify both exist after `bcgasl` / `c-bpm-cm-library-pull`. If only one is popul
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/gh-issue-create-guard.sh"
+            "command": "node ~/.claude/hooks/dist/issue-write-gate.mjs",
+            "timeout": 10
           }
         ]
       }
@@ -131,7 +134,11 @@ Verify both exist after `bcgasl` / `c-bpm-cm-library-pull`. If only one is popul
 }
 ```
 
-The hook script reads the tool input (the bash command) from stdin/env, greps for `gh issue create` / `gh api .../issues` / `curl ... /issues` / `mcp__*__create_issue`, and exits non-zero with a clear stderr message if `--milestone` and a type label (`bug` or `enhancement`) are missing. See the authoritative Claude Code hooks docs for exact event names, matcher syntax, and stdin schema before implementing.
+The hook reads the tool invocation as JSON on **stdin** (`{tool_name, tool_input, cwd}`), matches `gh issue create` / `gh api repos/.../issues` (POST) / `mcp__github__create_issue` / `mcp__github__issue_write`, and returns a **PreToolUse permission decision on stdout** (`deny` with a reason, `allow` otherwise) while **exiting 0** — it does not block via non-zero exit. If `--milestone` or a single `bug`/`enhancement` type label is missing, it denies.
+
+**Verified against** the authoritative Claude Code hooks docs (event names, matcher syntax, `{type, command, timeout}` shape, and the PreToolUse decision/stdin schema):
+- <a href="https://code.claude.com/docs/en/hooks-guide.md" target="_blank">hooks-guide</a>
+- <a href="https://code.claude.com/docs/en/hooks.md" target="_blank">hooks reference</a>
 
 ### Required coverage for issue creation
 

--- a/my/commands/c-bpm-cm-openissues-team.md
+++ b/my/commands/c-bpm-cm-openissues-team.md
@@ -134,7 +134,7 @@ Show:
    - Teammate name (descriptive role)
    - Assigned issue numbers
    - File scope (which files they may touch)
-   - Model: **Opus 4.6** (all teammates)
+   - Model: **newest Opus (see `c-bpm-sk-llm-selection`)** (all teammates)
 
 **WAIT for user confirmation before creating the team.**
 
@@ -143,7 +143,7 @@ Show:
 ## PHASE 3 — SPAWN AGENT TEAM
 
 ### Model Policy
-- **ALL teammates use Opus 4.6** — no exceptions
+- **ALL teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no exceptions
 - Document this in each task description
 
 ### Teammate Naming
@@ -206,7 +206,7 @@ Teammate submits plan (via ExitPlanMode)
   -> Team Lead moves issue to milestone: planned
   -> Team Lead executes Codex review:
 
-     codex exec --skip-git-repo-check -m gpt-5.2 "Review this implementation plan for Issue #<N>. Plan: <plan-summary>. REQUIREMENTS: 1) Test coverage must be included. 2) Changes must be scoped to assigned files. 3) Risk assessment present. 4) Rollback strategy present. Approve or reject with specific reasons."
+     codex exec --skip-git-repo-check "Review this implementation plan for Issue #<N>. Plan: <plan-summary>. REQUIREMENTS: 1) Test coverage must be included. 2) Changes must be scoped to assigned files. 3) Risk assessment present. 4) Rollback strategy present. Approve or reject with specific reasons."
 
   -> Codex result posted as comment on the GitHub Issue
   -> If BOTH Team Lead AND Codex approve:
@@ -237,7 +237,7 @@ Teammate submits test design (message to team-lead)
   -> Team Lead moves issue to milestone: test-designed
   -> Team Lead executes Codex review:
 
-     codex exec --skip-git-repo-check -m gpt-5.2 "Review test design for Issue #<N>. Tests: <test-description>. Check: edge cases covered, meaningful assertions, no false positives, adequate coverage, follows project test framework (test_framework.sh). Approve or reject."
+     codex exec --skip-git-repo-check "Review test design for Issue #<N>. Tests: <test-description>. Check: edge cases covered, meaningful assertions, no false positives, adequate coverage, follows project test framework (test_framework.sh). Approve or reject."
 
   -> Codex result posted as comment on the GitHub Issue
   -> If BOTH approve:
@@ -276,7 +276,7 @@ Team Lead:
   -> Spot-check test quality
 
 Team Lead executes:
-  codex exec --skip-git-repo-check -m gpt-5.2 "Verify implementation and test results for Issue #<N>. Changes: <summary>. Check: tests passing legitimately, no false positives, test coverage adequate, code quality acceptable. Approve or reject."
+  codex exec --skip-git-repo-check "Verify implementation and test results for Issue #<N>. Changes: <summary>. Check: tests passing legitimately, no false positives, test coverage adequate, code quality acceptable. Approve or reject."
 
   -> Verification results posted as comment on the GitHub Issue
   -> If BOTH approve -> Team Lead moves issue to milestone: test-approved — ready for human DONE sign-off
@@ -310,7 +310,7 @@ After all workable issues are addressed:
 ## CODEX RULES (NON-NEGOTIABLE)
 
 - Codex is the **PRIMARY REVIEW AUTHORITY** for all Claude-generated work
-- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check -m gpt-5.2 "<review-prompt>"`
+- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check "<review-prompt>"`
 - Codex review is **MANDATORY** at 3 gates:
   1. Plan approval (Phase 4)
   2. Test design approval (Phase 5)
@@ -337,5 +337,5 @@ After all workable issues are addressed:
 - Team Lead DOES: spawn teammates, send messages, manage tasks, run Codex reviews, manage GitHub Issues via MCP, run verification tests
 - Communication via shared task list and messages
 - File conflicts -> Team Lead resolves by reassigning scope
-- **All teammates use Opus 4.6** — no model escalation needed
+- **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no model escalation needed
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to be set

--- a/my/commands/c-bpm-cm-refactor-repo.md
+++ b/my/commands/c-bpm-cm-refactor-repo.md
@@ -146,7 +146,7 @@ WAIT for user confirmation before creating the team.
 ## PHASE 3 — SPAWN AGENT TEAM
 
 ### Model Policy
-- **ALL teammates use Opus 4.6** — no exceptions
+- **ALL teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no exceptions
 - Document this in each task description
 
 ### Teammate Naming
@@ -198,7 +198,7 @@ Teammate submits plan
   → Team Lead moves issue to milestone: planned
   → Team Lead reviews
   → Team Lead executes:
-    codex exec --skip-git-repo-check -m gpt-5.2 "Review this refactoring plan for <teammate-name>: <plan-summary>. Assess: completeness, test coverage, risk, safety. Approve or reject with reasons."
+    codex exec --skip-git-repo-check "Review this refactoring plan for <teammate-name>: <plan-summary>. Assess: completeness, test coverage, risk, safety. Approve or reject with reasons."
   → Codex result added as comment to the GitHub Issue
   → If BOTH approve → move issue to milestone: plan-approved
   → If EITHER rejects → issue stays at planned, rejection reason in comment, teammate revises
@@ -223,7 +223,7 @@ Teammate submits test design
   → Team Lead moves issue to milestone: test-designed
   → Team Lead reviews
   → Team Lead executes:
-    codex exec --skip-git-repo-check -m gpt-5.2 "Review test designs for <teammate-name>: <test-file-paths>. Check: edge cases, meaningful assertions, no false positives, adequate coverage. Approve or reject."
+    codex exec --skip-git-repo-check "Review test designs for <teammate-name>: <test-file-paths>. Check: edge cases, meaningful assertions, no false positives, adequate coverage. Approve or reject."
   → Codex result added as comment to the GitHub Issue
   → If BOTH approve → move issue to milestone: test-design-approved
   → If EITHER rejects → issue stays at test-designed, rejection reason in comment, teammate revises
@@ -261,7 +261,7 @@ Team Lead:
   → Spot-check the test quality: are assertions meaningful? edge cases covered?
 
 Team Lead executes:
-  codex exec --skip-git-repo-check -m gpt-5.2 "Verify test results for <teammate-name>. Changes: <summary>. Run tests and review: are tests passing legitimately? Any false positives? Test coverage adequate? Approve or reject."
+  codex exec --skip-git-repo-check "Verify test results for <teammate-name>. Changes: <summary>. Run tests and review: are tests passing legitimately? Any false positives? Test coverage adequate? Approve or reject."
 
   → Verification results added as comment to the GitHub Issue
   → If BOTH approve → move issue to milestone: test-approved
@@ -300,7 +300,7 @@ After all issues reach `test-approved`:
 ## CODEX RULES
 
 - Codex is the PRIMARY REVIEW AUTHORITY for all Claude-generated code
-- Codex MUST be invoked ONLY via shell: `codex exec --skip-git-repo-check -m gpt-5.2 "<review-prompt>"`
+- Codex MUST be invoked ONLY via shell: `codex exec --skip-git-repo-check "<review-prompt>"`
 - Codex review is MANDATORY at 3 gates: plan approval, test design approval, test verification
 - If Codex is unavailable (command fails): STOP → notify user → do NOT proceed without Codex
 - Log all Codex responses as comments in the corresponding GitHub Issue
@@ -314,5 +314,5 @@ After all issues reach `test-approved`:
 - Team Lead DOES: spawn teammates, send messages, manage tasks, run Codex reviews, manage GitHub Issues/Milestones via MCP, run targeted verification tests
 - Communication via shared task list and messages
 - File conflicts → Team Lead resolves by reassigning scope
-- **All teammates use Opus 4.6** — no model escalation needed
+- **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no model escalation needed
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to be set

--- a/my/commands/c-bpm-cm-skill-creator.md
+++ b/my/commands/c-bpm-cm-skill-creator.md
@@ -90,7 +90,7 @@ cp -r ~/.claude/plugins/marketplaces/anthropic-agent-skills/skills/<original>/ ~
 ### Step 5: Codex Review
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this Claude Code skill for quality. Check for:
+codex exec --skip-git-repo-check "Review this Claude Code skill for quality. Check for:
 1. Frontmatter: name (c-bpm-sk- prefix) and description (includes trigger conditions)
 2. Progressive disclosure: SKILL.md under 500 lines, references split out
 3. No duplication between SKILL.md and reference files

--- a/my/commands/c-bpm-cm-skill-optimizer.md
+++ b/my/commands/c-bpm-cm-skill-optimizer.md
@@ -99,7 +99,7 @@ Codex is the review authority for skill quality. All non-trivial skill changes g
 ### Invocation
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this Claude Code skill for quality. Check for:
+codex exec --skip-git-repo-check "Review this Claude Code skill for quality. Check for:
 1. Frontmatter: name and description are clear, description includes trigger conditions
 2. Progressive disclosure: SKILL.md under 500 lines, references split out properly
 3. No duplication between SKILL.md and reference files

--- a/my/skills/c-bpm-sk-auditor/SKILL.md
+++ b/my/skills/c-bpm-sk-auditor/SKILL.md
@@ -43,7 +43,7 @@ A single Markdown file: `[REPONAME]-YYMMDD-HHSS.md` in the repo root.
      Discovery  Audit      Analysis     & Quality
 ```
 
-**Minimum 2, maximum 10 teammates. All use Opus 4.6 (inherit, never haiku).**
+**Minimum 2, maximum 10 teammates. All use newest Opus (see `c-bpm-sk-llm-selection`) (inherit, never haiku).**
 
 ## Audit Phases
 
@@ -163,10 +163,10 @@ Write `[REPONAME]-YYMMDD-HHSS.md`, send shutdown_request to all teammates, TeamD
 - Produce exactly one `.md` report file
 - Run independent devil's advocate review after EACH phase (Codex primary, Gemini/other as fallback)
 - Spawn at minimum 2 teammates, maximum 10
-- Use Opus 4.6 for all teammates (inherit, never haiku)
+- Use newest Opus (see `c-bpm-sk-llm-selection`) for all teammates (inherit, never haiku)
 - Include severity ratings for all findings
 - Run existing tests if safe to do so
-- Invoke Codex ONLY via: `codex exec --skip-git-repo-check -m gpt-5.2 [PROMPT]` (if unavailable, use fallback chain)
+- Invoke Codex ONLY via: `codex exec --skip-git-repo-check [PROMPT]` (if unavailable, use fallback chain)
 
 ### MUST NOT
 - Create GitHub issues (report only)

--- a/my/skills/c-bpm-sk-auditor/references/codex-prompts.md
+++ b/my/skills/c-bpm-sk-auditor/references/codex-prompts.md
@@ -1,31 +1,31 @@
 # Codex Devil's Advocate Prompts
 
-Codex MUST be invoked ONLY via shell: `codex exec --skip-git-repo-check -m gpt-5.2 [PROMPT]`
+Codex MUST be invoked ONLY via shell: `codex exec --skip-git-repo-check [PROMPT]`
 
 ## Per-Phase Reviews
 
 ### After Phase 1 (Codebase Understanding)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Devil's advocate review of codebase analysis for [REPONAME]. Challenge: 1) Is the tech stack detection complete? Any frameworks/tools missed? 2) Is the architecture description accurate or oversimplified? 3) Are there hidden entry points or config files not found? 4) Any dependency risks not flagged? Findings: [PHASE 1 SUMMARY]"
+codex exec --skip-git-repo-check "Devil's advocate review of codebase analysis for [REPONAME]. Challenge: 1) Is the tech stack detection complete? Any frameworks/tools missed? 2) Is the architecture description accurate or oversimplified? 3) Are there hidden entry points or config files not found? 4) Any dependency risks not flagged? Findings: [PHASE 1 SUMMARY]"
 ```
 
 ### After Phase 2 (Pattern Checks)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Devil's advocate review of pattern analysis for [REPONAME] ([TECH STACK]). Challenge: 1) False positives - issues flagged that aren't real problems in this stack 2) Missed anti-patterns common in [FRAMEWORK] projects 3) Are security findings real vulnerabilities or theoretical? 4) Performance concerns - are they measurable or speculative? 5) Migration safety - any destructive patterns missed? Findings: [PHASE 2 SUMMARY]"
+codex exec --skip-git-repo-check "Devil's advocate review of pattern analysis for [REPONAME] ([TECH STACK]). Challenge: 1) False positives - issues flagged that aren't real problems in this stack 2) Missed anti-patterns common in [FRAMEWORK] projects 3) Are security findings real vulnerabilities or theoretical? 4) Performance concerns - are they measurable or speculative? 5) Migration safety - any destructive patterns missed? Findings: [PHASE 2 SUMMARY]"
 ```
 
 ### After Phase 3 (Test Plan)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Devil's advocate review of test plan for [REPONAME]. Challenge: 1) Are coverage gaps real or already tested indirectly? 2) Are recommended tests practical and valuable? 3) Any critical paths missed entirely? 4) Is the test execution plan safe (no side effects)? Test plan: [PHASE 3 SUMMARY]"
+codex exec --skip-git-repo-check "Devil's advocate review of test plan for [REPONAME]. Challenge: 1) Are coverage gaps real or already tested indirectly? 2) Are recommended tests practical and valuable? 3) Any critical paths missed entirely? 4) Is the test execution plan safe (no side effects)? Test plan: [PHASE 3 SUMMARY]"
 ```
 
 ### Final Review (Complete Report)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Final devil's advocate review of complete audit report for [REPONAME]. Challenge every finding. Are there false positives? Missed issues? Is severity accurate? Are recommendations actionable? Full report: [REPORT CONTENT]"
+codex exec --skip-git-repo-check "Final devil's advocate review of complete audit report for [REPONAME]. Challenge every finding. Are there false positives? Missed issues? Is severity accurate? Are recommendations actionable? Full report: [REPORT CONTENT]"
 ```
 
 ## Rules

--- a/my/skills/c-bpm-sk-auditor/references/report-template.md
+++ b/my/skills/c-bpm-sk-auditor/references/report-template.md
@@ -5,7 +5,7 @@ Use this template for the final `[REPONAME]-YYMMDD-HHSS.md` output.
 ```markdown
 # Repository Audit: [REPONAME]
 **Date:** YYYY-MM-DD HH:SS
-**Audited by:** Claude Opus 4.6 + OpenAI Codex (devil's advocate)
+**Audited by:** Claude (newest Opus) + OpenAI Codex (devil's advocate)
 
 ## Executive Summary
 [2-3 paragraph overview with risk rating: LOW / MEDIUM / HIGH / CRITICAL]

--- a/my/skills/c-bpm-sk-flightphp-pro/SKILL.md
+++ b/my/skills/c-bpm-sk-flightphp-pro/SKILL.md
@@ -187,7 +187,7 @@ Workflow phases:
 1. Discovery — scan repo, MCP servers, existing issues
 2. Security — audit dependencies (`composer audit`), scan for secrets
 3. Analysis — assess code quality, architecture, identify improvements
-4. Team spawn — assign issues to teammates (default: Opus 4.6)
+4. Team spawn — assign issues to teammates (default: newest Opus (see `c-bpm-sk-llm-selection`))
 5. Plan approval — dual gate (Team Lead + Codex)
 6. Test design — dual gate (Team Lead + Codex)
 7. Implementation — feature branches, TDD, no breakage

--- a/my/skills/c-bpm-sk-flightphp-pro/references/team-orchestration.md
+++ b/my/skills/c-bpm-sk-flightphp-pro/references/team-orchestration.md
@@ -164,11 +164,11 @@ Present a summary to the user:
 
 ### Model Policy
 
-Use Opus 4.6 for all teammates:
+Use newest Opus (see `c-bpm-sk-llm-selection`) for all teammates:
 
 | Model | When to Use |
 |-------|------------|
-| **Opus 4.6** (default) | All tasks — single-file changes, refactoring, test writing, documentation, complex logic |
+| **newest Opus (see `c-bpm-sk-llm-selection`)** (default) | All tasks — single-file changes, refactoring, test writing, documentation, complex logic |
 
 Do not use Haiku or Sonnet for teammates.
 
@@ -214,7 +214,7 @@ The teammate posts a plan as a comment on their assigned issue(s). The plan must
 1. **Team Lead reviews** — Checks scope adherence, architectural fit, completeness
 2. **Codex reviews** — Run:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this plan for issue #N in a Flight PHP project. Check for: scope creep, missing test coverage, architectural violations, security concerns. Plan: <plan content>"
+   codex exec --skip-git-repo-check "Review this plan for issue #N in a Flight PHP project. Check for: scope creep, missing test coverage, architectural violations, security concerns. Plan: <plan content>"
    ```
 
 ### Approval Criteria
@@ -271,7 +271,7 @@ final class UserControllerTest extends TestCase
 1. **Team Lead reviews** — Checks coverage completeness, edge cases, isolation
 2. **Codex reviews** — Run:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this PHPUnit test design for a Flight PHP project. Check for: adequate coverage, proper Engine isolation, missing edge cases, assertion quality. Test design: <test design content>"
+   codex exec --skip-git-repo-check "Review this PHPUnit test design for a Flight PHP project. Check for: adequate coverage, proper Engine isolation, missing edge cases, assertion quality. Test design: <test design content>"
    ```
 
 ### Approval
@@ -333,7 +333,7 @@ Team Lead and Codex independently verify:
 1. **Team Lead** — Pulls the branch, runs tests, reviews code
 2. **Codex** — Run:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this implementation for a Flight PHP project. Check: tests pass, code follows Flight conventions, no security issues, no breaking changes. Code diff: <diff content>"
+   codex exec --skip-git-repo-check "Review this implementation for a Flight PHP project. Check: tests pass, code follows Flight conventions, no security issues, no breaking changes. Code diff: <diff content>"
    ```
 
 Both must approve. Move to milestone: `test-approved`.
@@ -383,7 +383,7 @@ Independent review is mandatory for all Claude-generated code (Codex primary, Ge
 Codex is invoked ONLY via:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "<review prompt>"
+codex exec --skip-git-repo-check "<review prompt>"
 ```
 
 Never use interactive mode. Never skip independent review at mandatory gates (use fallback chain if Codex unavailable).
@@ -400,7 +400,7 @@ Independent review (Codex → Gemini → other) is required at exactly 3 gates:
 
 Try the fallback chain before stopping:
 
-1. **Primary:** `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"`
+1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
 2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
 3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
 

--- a/my/skills/c-bpm-sk-grill-claude-issue/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-claude-issue/SKILL.md
@@ -97,7 +97,7 @@ Budgets:
 
 1. **Claude calls Codex** with the structured prompt:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "<structured prompt with all input fields>"
+   codex exec --skip-git-repo-check "<structured prompt with all input fields>"
    ```
 2. **Codex returns** a question (or verdict if satisfied on the current branch)
 3. **Claude researches actively** — read code, grep patterns, consult relevant
@@ -115,10 +115,14 @@ Budgets:
 
 ### Handling Disagreement
 
-If Codex and Claude cannot agree after all follow-ups on a branch:
-- Document as "unresolved" with both positions stated
-- Move to the next main question
-- Include in final summary for user decision
+Disagreement is not a terminal state. Per the canonical Codex Review Loop in
+`c-bpm-sk-llm-selection`, the branch stays open until Codex returns a verdict:
+
+- Claude (Producer) revises its answer with additional research and evidence and
+  re-submits to Codex on the same branch.
+- Codex re-reviews and returns either a follow-up question or a verdict.
+- Repeat until Codex issues a verdict. There is no abandonment without a verdict, and
+  never a third model or the user brought in to break a tie.
 
 ## Claude's Answer Behavior
 
@@ -199,7 +203,7 @@ Present the summary to the user after posting:
 
 ## Codex Fallback Chain
 
-1. **Primary**: `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"`
+1. **Primary**: `codex exec --skip-git-repo-check "<prompt>"`
 2. **Fallback 1**: `gemini` CLI with equivalent prompt
 3. **Fallback 2**: notify user that devil's advocate must be done manually —
    "Codex and Gemini unavailable. Run the review manually or retry later."

--- a/my/skills/c-bpm-sk-grill-me-issue/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-me-issue/SKILL.md
@@ -162,7 +162,7 @@ Both paths execute the full wrap-up protocol.
    - New issues created (if any, with links)
 3. **Codex Devil's Advocate** review:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this refined GitHub Issue #{number}: [title]. Refined content: [summary]. Challenge: 1) Are requirements complete and testable? 2) What edge cases are missing? 3) Is acceptance criteria clear? 4) Any scope creep?"
+   codex exec --skip-git-repo-check "Review this refined GitHub Issue #{number}: [title]. Refined content: [summary]. Challenge: 1) Are requirements complete and testable? 2) What edge cases are missing? 3) Is acceptance criteria clear? 4) Any scope creep?"
    ```
    Post the Codex response as an issue comment.
 4. **Codex fallback chain**: `codex` -> `gemini` -> notify user that Devil's

--- a/my/skills/c-bpm-sk-grill-me/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-me/SKILL.md
@@ -182,7 +182,7 @@ When all branches are resolved (or stop signal received):
 
 4. **Codex Devil's Advocate Review** — invoke:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this grilled idea documentation: [summary]. Challenge: 1) Are there gaps in the analysis? 2) What assumptions were not questioned? 3) Is the documentation complete enough for someone else to implement? 4) What is the biggest risk that was not addressed?"
+   codex exec --skip-git-repo-check "Review this grilled idea documentation: [summary]. Challenge: 1) Are there gaps in the analysis? 2) What assumptions were not questioned? 3) Is the documentation complete enough for someone else to implement? 4) What is the biggest risk that was not addressed?"
    ```
    Post the Codex response into the output MD file under a `## Devil's Advocate`
    heading.

--- a/my/skills/c-bpm-sk-idea-merge/SKILL.md
+++ b/my/skills/c-bpm-sk-idea-merge/SKILL.md
@@ -117,7 +117,7 @@ Proposed action: <ACTION_TYPE> — <specific steps>
 Before ANY mutations, invoke Codex for review:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 \
+codex exec --skip-git-repo-check \
   "Review these proposed changes for [repo]: [cluster summary with proposed actions]. \
    Are groupings warranted? Should any items be split instead? \
    Missing items that belong in a cluster?"

--- a/my/skills/c-bpm-sk-linux-admin/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-admin/SKILL.md
@@ -167,7 +167,7 @@ Show:
 ## PHASE 3 — SPAWN ADMIN TEAM
 
 ### Model Policy
-- **ALL teammates use Opus 4.6** — no exceptions
+- **ALL teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no exceptions
 
 ### Teammate Instructions
 
@@ -213,7 +213,7 @@ Teammate submits plan (via ExitPlanMode)
   → Team Lead updates issue milestone to `planned`
   → Team Lead executes Codex review:
 
-     codex exec --skip-git-repo-check -m gpt-5.2 "Review this Linux administration fix plan
+     codex exec --skip-git-repo-check "Review this Linux administration fix plan
      for Issue #<N> on a Debian/Ubuntu host. Plan: <plan-summary>.
      REQUIREMENTS: 1) Pre-checks verify current state. 2) Commands correct for
      Debian/Ubuntu. 3) Validation confirms fix. 4) Rollback is safe and complete.
@@ -268,7 +268,7 @@ Team Lead:
   → Posts verification results as comment on GitHub Issue
 
 Team Lead executes:
-  codex exec --skip-git-repo-check -m gpt-5.2 "Verify this Linux administration fix for
+  codex exec --skip-git-repo-check "Verify this Linux administration fix for
   Issue #<N>. Fix applied: <summary>. Verification: <evidence>.
   Check: 1) Fix correctly applied. 2) No side effects. 3) Validation genuine.
   4) System in expected state. Approve or reject with reasons."
@@ -294,7 +294,7 @@ After all workable issues are addressed:
 
 3. Final Codex review:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this Linux administration session
+   codex exec --skip-git-repo-check "Review this Linux administration session
    report for host {hostname}. Check: 1) All fixes properly verified.
    2) No security regressions. 3) System stability maintained.
    4) Rollback plans documented. Report: {report-content}"
@@ -315,7 +315,7 @@ After all workable issues are addressed:
 ## Codex Rules (NON-NEGOTIABLE)
 
 - Independent review is **MANDATORY** for all fixes (Codex primary, Gemini/other as fallback)
-- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"` (if unavailable, use fallback chain)
+- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check "<prompt>"` (if unavailable, use fallback chain)
 - Independent review is **MANDATORY** at 2 gates (try Codex → Gemini → other): Plan approval (Phase 4), Verification (Phase 6)
 - Log ALL reviewer responses as comments on the corresponding GitHub Issue
 
@@ -323,7 +323,7 @@ After all workable issues are addressed:
 
 Try the fallback chain before stopping:
 
-1. **Primary:** `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"`
+1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
 2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
 3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
 
@@ -361,5 +361,5 @@ See `c-bpm-sk-milestone-type` for full milestone definitions and transition rule
 
 - Team Lead MUST stay in DELEGATE MODE at all times (except Phase 0 bootstrap and read-only verification)
 - Communication via shared task list and messages
-- **All teammates use Opus 4.6**
+- **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)**
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`

--- a/my/skills/c-bpm-sk-linux-archive/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-archive/SKILL.md
@@ -162,7 +162,7 @@ After archiving, update the installed-tools table in MEMORY.md:
 Before executing any destructive or irreversible operation (config backup, git commit, git push), submit plan to Codex for review:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this archive plan: <plan>. Check: no secrets exposed, correct file selection, follows project conventions. Approve or reject."
+codex exec --skip-git-repo-check "Review this archive plan: <plan>. Check: no secrets exposed, correct file selection, follows project conventions. Approve or reject."
 ```
 
 If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: STOP and notify the user.

--- a/my/skills/c-bpm-sk-linux-audit/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-audit/SKILL.md
@@ -66,7 +66,7 @@ Before proceeding to Phase 1, confirm ALL of these:
 
 ### 1a. Team Structure
 
-Spawn **3 audit teammates** (all Opus 4.6), each responsible for one audit category:
+Spawn **3 audit teammates** (all newest Opus (see `c-bpm-sk-llm-selection`)), each responsible for one audit category:
 
 | Teammate | Category | Scope |
 |---|---|---|
@@ -83,7 +83,7 @@ Show the team plan and **WAIT for confirmation** before spawning.
 ## PHASE 2 — SPAWN AUDIT TEAM
 
 ### Model Policy
-- **ALL teammates use Opus 4.6** — no exceptions
+- **ALL teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no exceptions
 
 ### Teammate Instructions
 
@@ -125,7 +125,7 @@ Teammate submits plan (via ExitPlanMode)
   → Team Lead reviews findings
   → Team Lead executes Codex review:
 
-    codex exec --skip-git-repo-check -m gpt-5.2 "Review these Linux audit findings for host {hostname}.
+    codex exec --skip-git-repo-check "Review these Linux audit findings for host {hostname}.
     Category: {category}. Findings: {findings-summary}.
     Check: 1) Severity ratings are appropriate. 2) No false positives.
     3) Fix steps are correct and safe. 4) Issue types (BUG vs ENHANCEMENT) are correct.
@@ -209,7 +209,7 @@ Post as a new issue titled "Audit Run {YYYY-MM-DD}":
 ### Codex Final Review
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this Linux audit summary for host {hostname}.
+codex exec --skip-git-repo-check "Review this Linux audit summary for host {hostname}.
 Check: 1) All major audit areas covered (runtime, security, health).
 2) Severity ratings consistent. 3) No critical findings missed.
 4) Summary is complete. Summary: {summary-content}"
@@ -277,7 +277,7 @@ No labels. No tags. Issue type + milestone = full lifecycle tracking.
 ## Codex Rules (NON-NEGOTIABLE)
 
 - Independent review is **MANDATORY** for all findings (Codex primary, Gemini/other as fallback)
-- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"` (if unavailable, use fallback chain)
+- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check "<prompt>"` (if unavailable, use fallback chain)
 - Independent review is **MANDATORY** at 2 gates (try Codex → Gemini → other):
   1. Findings approval (Phase 3)
   2. Audit summary review (Phase 5)
@@ -287,7 +287,7 @@ No labels. No tags. Issue type + milestone = full lifecycle tracking.
 
 Try the fallback chain before stopping:
 
-1. **Primary:** `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"`
+1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
 2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
 3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
 
@@ -312,5 +312,5 @@ If ALL models in the chain are unavailable:
 
 - Team Lead MUST stay in DELEGATE MODE at all times (except Phase 0 bootstrap)
 - Communication via shared task list and messages
-- **All teammates use Opus 4.6**
+- **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)**
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`

--- a/my/skills/c-bpm-sk-llm-selection/SKILL.md
+++ b/my/skills/c-bpm-sk-llm-selection/SKILL.md
@@ -19,6 +19,21 @@ How the Orchestrator selects and delegates tasks to available LLMs, and how the 
 | **Codex** | Implementer | Fast code generation, completions | Routine code tasks, quick completions, high-volume generation |
 | **Gemini** | Substitute Judge (Codex unreachable only) / Large-Context Reader | Large context, multimodal, alternate Judge when Codex is offline | Large document analysis, image processing, substitute Judge in the review loop ONLY when Codex is unreachable |
 
+## Model Version Policy (single source — referenced everywhere)
+
+This section is the single source of truth for model selection. No other skill or
+command may name a concrete model version; they reference this section.
+
+- **Codex (Judge / implementer):** invoke WITHOUT `-m`. Codex follows its own CLI
+  default model. Never pin a Codex model version flag in any skill or command.
+- **Claude teammates:** always the newest Opus (via `model: opus` / inherit). Never
+  pin a numeric Opus version.
+- **OpenRouter (if installed):** for cross-model validation only, and a substitute
+  Judge ONLY when Codex is unreachable (same rule as Gemini). Never a co-Judge,
+  tiebreaker, or third model in the Producer↔Codex loop. Not for daily work (see #47).
+- **Fable:** not yet adopted for production roles (too new). Revisit later.
+- Every other skill and command references THIS section, never names a version.
+
 ## Rules
 
 ### Orchestrator Selection
@@ -93,6 +108,47 @@ This pattern is referenced by `c-bpm-sk-skill-creator`, `c-bpm-sk-skill-optimize
 `c-bpm-cm-openissues-team`, and every other skill or command that runs a Codex
 review gate. It is the canonical definition; downstream skills must remain
 consistent with it.
+
+## Codex Invocation (shell hygiene)
+
+This is the canonical shell form for invoking the Codex Judge — the form the Team
+Lead uses at review gates and that new skills should adopt. Migrating the existing
+inline `codex exec` examples across the library to this sanitized form is tracked in
+#94 (in progress); until that lands, those call sites remain the plain
+`codex exec --skip-git-repo-check` form.
+
+**Problem it solves (issue #94):** Codex's captured output must contain *only*
+Codex's verdict. When `codex exec` is run from a login/rc-sourcing shell, the
+profile/rc side-effects — `keychain`, `ssh-agent`, `curl` to raw.githubusercontent.com,
+etc. — are emitted into the captured output. Codex then misreads that startup
+chatter as file content under review and returns false-positive rejections
+(observed: three fabricated review failures in a single session). Because
+Codex's own internal shells inherit the parent environment, the fix is to clear
+`BASH_ENV`/`ENV` and disable profile/rc in the invoking shell so nothing
+downstream re-sources them.
+
+**Canonical form** — sanitized, non-login shell, prompt on stdin:
+
+```bash
+env -u BASH_ENV -u ENV bash --noprofile --norc -c \
+  'codex exec --skip-git-repo-check < prompt.md 2>&1'
+```
+
+**Rules**
+
+- **Sanitize the environment.** `env -u BASH_ENV -u ENV` strips the variables
+  that cause non-interactive shells (including Codex's own) to source rc files.
+- **No login/rc shell.** `bash --noprofile --norc` — never `bash -l`, `bash -lc`,
+  or any shell that sources `~/.bash_profile` / `~/.bashrc` / `~/.profile`.
+- **Prompt on stdin.** Pass the review prompt via `< prompt.md`, never as a large
+  inline argv (it hangs).
+- **Verdict-only output.** A clean invocation emits only Codex's review verdict —
+  no `keychain`, `ssh-agent`, or `curl` startup lines.
+
+> The definitive cure for the leak is guarding `keychain` to interactive shells
+> only in the host's shell rc (a `bpm-<host>` dotfiles concern, tracked
+> separately); this sanitized invocation is the library-side mitigation that
+> holds regardless of host dotfile state.
 
 ## LLM Availability Handoff
 

--- a/my/skills/c-bpm-sk-milestone-type/SKILL.md
+++ b/my/skills/c-bpm-sk-milestone-type/SKILL.md
@@ -223,7 +223,7 @@ Open issues: 12
 ### Gate 1: Plan Approval (planned -> plan-approved)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this implementation plan for Issue #<N>. \
+codex exec --skip-git-repo-check "Review this implementation plan for Issue #<N>. \
 Plan: <plan-summary>. \
 REQUIREMENTS: 1) Test coverage must be included. 2) Changes scoped to assigned files. \
 3) Risk assessment present. 4) Rollback strategy present. \
@@ -233,7 +233,7 @@ Approve or reject with specific reasons."
 ### Gate 2: Test Design Approval (test-designed -> test-design-approved)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review test design for Issue #<N>. \
+codex exec --skip-git-repo-check "Review test design for Issue #<N>. \
 Tests: <test-description>. \
 Check: edge cases covered, meaningful assertions, no false positives, \
 adequate coverage, follows project test framework. Approve or reject."
@@ -242,7 +242,7 @@ adequate coverage, follows project test framework. Approve or reject."
 ### Gate 3: Test Verification (tested-success -> test-approved)
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Verify implementation and test results for Issue #<N>. \
+codex exec --skip-git-repo-check "Verify implementation and test results for Issue #<N>. \
 Changes: <summary>. \
 Check: tests passing legitimately, no false positives, test coverage adequate, \
 code quality acceptable. Approve or reject."
@@ -252,7 +252,7 @@ code quality acceptable. Approve or reject."
 
 Try the fallback chain before stopping:
 
-1. **Primary:** `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"`
+1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
 2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
 3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
 

--- a/my/skills/c-bpm-sk-question-auditor/references/report-template.md
+++ b/my/skills/c-bpm-sk-question-auditor/references/report-template.md
@@ -15,7 +15,7 @@ Use this template when generating the audit report.
 | Filter | {published / unpublished / all} |
 | Certificate Level | {Foundation / Professional / unknown} |
 | Audit Date | {YYYY-MM-DD HH:MM:SS} |
-| Auditor | Claude Opus 4.6 -- `c-bpm-sk-question-auditor` |
+| Auditor | Claude (newest Opus) -- `c-bpm-sk-question-auditor` |
 | Questions Audited | {total_count} |
 | Previous Report | {filename or "none"} |
 

--- a/my/skills/c-bpm-sk-release-ops/SKILL.md
+++ b/my/skills/c-bpm-sk-release-ops/SKILL.md
@@ -53,7 +53,7 @@ jobs:
 Before executing any destructive or irreversible operation (release cut, tag creation, artefact publishing), submit plan to Codex for review:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this release plan: <plan>. Check: correct versioning, no breaking changes, follows project conventions. Approve or reject."
+codex exec --skip-git-repo-check "Review this release plan: <plan>. Check: correct versioning, no breaking changes, follows project conventions. Approve or reject."
 ```
 
 If Codex is unavailable: STOP and notify the user.

--- a/my/skills/c-bpm-sk-repo-scaffold/SKILL.md
+++ b/my/skills/c-bpm-sk-repo-scaffold/SKILL.md
@@ -48,7 +48,7 @@ Provide a consistent starting point for new projects, ensuring that directory la
 Before executing any destructive or irreversible operation (directory scaffolding, file overwriting, project restructuring), submit plan to Codex for review:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this scaffold plan: <plan>. Check: correct structure, no breaking changes, follows project conventions. Approve or reject."
+codex exec --skip-git-repo-check "Review this scaffold plan: <plan>. Check: correct structure, no breaking changes, follows project conventions. Approve or reject."
 ```
 
 If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: STOP and notify the user.

--- a/my/skills/c-bpm-sk-skill-creator/SKILL.md
+++ b/my/skills/c-bpm-sk-skill-creator/SKILL.md
@@ -120,7 +120,7 @@ Create scripts, references, assets as identified in Step 2.
 ### Step 5: Codex Review
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this Claude Code skill for Skills 2.0 compliance. Check:
+codex exec --skip-git-repo-check "Review this Claude Code skill for Skills 2.0 compliance. Check:
 1. Frontmatter: name (c-bpm-sk- prefix), description (triggers), Skills 2.0 fields
 2. Progressive disclosure: SKILL.md under 500 lines, references split out
 3. No duplication between SKILL.md and reference files

--- a/my/skills/c-bpm-sk-skill-optimizer/SKILL.md
+++ b/my/skills/c-bpm-sk-skill-optimizer/SKILL.md
@@ -109,7 +109,7 @@ Document what will change and why. Present to user for approval.
 ### Step 4: Codex Review
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this Claude Code skill for Skills 2.0 compliance. Check:
+codex exec --skip-git-repo-check "Review this Claude Code skill for Skills 2.0 compliance. Check:
 2. SKILL.md under 500 lines, references split out
 3. No duplication between SKILL.md and reference files
 4. Dynamic context injection used where beneficial

--- a/my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md
+++ b/my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md
@@ -117,11 +117,11 @@ Present a summary:
 
 ### Model Policy
 
-Use Opus 4.6 for all teammates:
+Use newest Opus (see `c-bpm-sk-llm-selection`) for all teammates:
 
 | Model | When to Use |
 |-------|------------|
-| **Opus 4.6** (default) | All tasks — skill changes, forking, documentation, optimizations, restructuring |
+| **newest Opus (see `c-bpm-sk-llm-selection`)** (default) | All tasks — skill changes, forking, documentation, optimizations, restructuring |
 
 Do not use Haiku or Sonnet for teammates.
 
@@ -164,7 +164,7 @@ The teammate posts a plan as a comment on their assigned issue. The plan must in
 1. **Team Lead reviews** — Checks scope, naming convention, segregation of duty
 2. **Codex reviews** — Run:
    ```bash
-   codex exec --skip-git-repo-check -m gpt-5.2 "Review this skill development plan. Check for: naming convention (c-bpm-sk- prefix), segregation of duty (original untouched), frontmatter quality, progressive disclosure, no unnecessary files. Plan: <plan content>"
+   codex exec --skip-git-repo-check "Review this skill development plan. Check for: naming convention (c-bpm-sk- prefix), segregation of duty (original untouched), frontmatter quality, progressive disclosure, no unnecessary files. Plan: <plan content>"
    ```
 
 ### Approval
@@ -201,7 +201,7 @@ When implementation is complete, move issue to milestone: `implemented`.
 ### Codex Skill Review
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "Review this Claude Code skill for quality. Check for:
+codex exec --skip-git-repo-check "Review this Claude Code skill for quality. Check for:
 1. Frontmatter: name and description are clear, description includes trigger conditions
 2. Progressive disclosure: SKILL.md under 500 lines, references split out properly
 3. No duplication between SKILL.md and reference files
@@ -253,7 +253,7 @@ Present a synthesis report to the user:
 Codex is invoked ONLY via:
 
 ```bash
-codex exec --skip-git-repo-check -m gpt-5.2 "<review prompt>"
+codex exec --skip-git-repo-check "<review prompt>"
 ```
 
 Never use interactive mode. Never skip independent review at mandatory gates (use fallback chain if Codex unavailable).
@@ -269,7 +269,7 @@ Independent review (Codex → Gemini → other) is required at exactly 2 gates:
 
 Try the fallback chain before stopping:
 
-1. **Primary:** `codex exec --skip-git-repo-check -m gpt-5.2 "<prompt>"`
+1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
 2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
 3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
 

--- a/tests/bash/c-bpm-claude-md-hook-refs.bats
+++ b/tests/bash/c-bpm-claude-md-hook-refs.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+#
+# c-bpm-claude-md-hook-refs.bats — guards CLAUDE.md's "Enforcement: Hooks,
+# Not Wrappers" section against doc/reality drift.
+#
+# Covers:
+#   #66 — CLAUDE.md must not reference the phantom gh-issue-create-guard.sh;
+#         the documented hook command must point at the real, shipped hook.
+#   #67 — CLAUDE.md must cite the authoritative Claude Code hooks docs URL.
+#
+# Offline & deterministic: plain grep against tracked files. Run with:
+#   bats tests/bash/c-bpm-claude-md-hook-refs.bats
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+DIST_HOOK="${REPO_ROOT}/dist/issue-write-gate.mjs"
+
+setup() {
+  [[ -f "${CLAUDE_MD}" ]] || skip "CLAUDE.md not found at ${CLAUDE_MD}"
+}
+
+@test "CLAUDE.md does not reference the phantom gh-issue-create-guard script (#66)" {
+  run grep -n "gh-issue-create-guard" "${CLAUDE_MD}"
+  [ "${status}" -ne 0 ]
+}
+
+@test "CLAUDE.md documents the exact real hook command (#66)" {
+  # Assert the full documented command, not just the basename, so a regression
+  # to a wrong path/executable is caught even if the basename lingers in prose.
+  run grep -F "node ~/.claude/hooks/dist/issue-write-gate.mjs" "${CLAUDE_MD}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "the hook documented in CLAUDE.md exists in dist/ (#66)" {
+  # Every hook command shown in CLAUDE.md must correspond to a shipped artifact.
+  [ -f "${DIST_HOOK}" ]
+}
+
+@test "CLAUDE.md cites the two verified Claude Code hooks docs URLs (#67)" {
+  # Lock in the exact URLs verified against; a permissive regex would pass even
+  # if the citations were dropped or swapped.
+  run grep -F "https://code.claude.com/docs/en/hooks-guide.md" "${CLAUDE_MD}"
+  [ "${status}" -eq 0 ]
+  run grep -F "https://code.claude.com/docs/en/hooks.md" "${CLAUDE_MD}"
+  [ "${status}" -eq 0 ]
+}

--- a/tests/bash/c-bpm-sk-codex-flag.bats
+++ b/tests/bash/c-bpm-sk-codex-flag.bats
@@ -1,116 +1,98 @@
 #!/usr/bin/env bats
 #
-# c-bpm-sk-codex-flag.bats - Guard against Issue #44 regression
+# c-bpm-sk-codex-flag.bats - Guard the single-source model policy (Issue #98)
 # Run with: bats tests/bash/c-bpm-sk-codex-flag.bats
 #
-# Purpose:
-#   codex CLI 0.94.0 defaults to gpt-5.2-codex which ChatGPT-auth accounts
-#   cannot use. Every `codex exec --skip-git-repo-check` invocation in this
-#   library MUST carry `-m gpt-5.2` so ChatGPT-auth users can execute the
-#   Codex review gates. This suite guarantees the flag is present on every
-#   invocation across every documented codex usage in my/.
+# History:
+#   Issue #44 (codex CLI 0.94) added `-m gpt-5.2` to every codex invocation
+#   because ChatGPT-auth accounts could not use the CLI default model.
+#   Issue #98 REVERSES that: on the current Codex CLI (0.128.0, default model
+#   gpt-5.4) the default works under ChatGPT auth, and `c-bpm-sk-llm-selection`
+#   is now the single source of truth for model selection. Every codex
+#   invocation MUST be bare (no `-m`), and no skill/command may hard-wire a
+#   Codex model version or a numeric Opus version. This suite locks that in.
+#
+#   NOTE: the guard regexes below intentionally contain "gpt-5"; this test file
+#   lives under tests/ (outside my/), so it does not trip the acceptance grep
+#   `grep -rn 'gpt-5' my/ = 0`.
 
 set -u
 
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
 
-# Files that document or invoke `codex exec --skip-git-repo-check`.
-# Keep this list in sync with the scope of Issue #44.
-AFFECTED_FILES=(
-  "my/skills/c-bpm-sk-auditor/SKILL.md"
-  "my/skills/c-bpm-sk-auditor/references/codex-prompts.md"
-  "my/skills/c-bpm-sk-skill-optimizer/SKILL.md"
-  "my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md"
-  "my/skills/c-bpm-sk-skill-creator/SKILL.md"
-  "my/skills/c-bpm-sk-release-ops/SKILL.md"
-  "my/skills/c-bpm-sk-repo-scaffold/SKILL.md"
-  "my/skills/c-bpm-sk-milestone-type/SKILL.md"
-  "my/skills/c-bpm-sk-linux-archive/SKILL.md"
-  "my/skills/c-bpm-sk-linux-audit/SKILL.md"
-  "my/skills/c-bpm-sk-linux-admin/SKILL.md"
-  "my/skills/c-bpm-sk-flightphp-pro/references/team-orchestration.md"
-  "my/skills/c-bpm-sk-grill-claude-issue/SKILL.md"
-  "my/skills/c-bpm-sk-grill-me-issue/SKILL.md"
-  "my/skills/c-bpm-sk-grill-me/SKILL.md"
-  "my/skills/c-bpm-sk-idea-merge/SKILL.md"
-  "my/commands/c-bpm-cm-openissues-team.md"
-  "my/commands/c-bpm-cm-refactor-repo.md"
-  "my/commands/c-bpm-cm-skill-creator.md"
-  "my/commands/c-bpm-cm-skill-optimizer.md"
-)
-
 # ------------------------------------------------------------------
-# Per-file: every affected file carries at least one fixed invocation
+# Acceptance 1: no hard-wired Codex model version anywhere under my/
 # ------------------------------------------------------------------
 
-@test "every affected file contains at least one 'codex exec --skip-git-repo-check -m gpt-5.2' invocation" {
-  local missing=()
-  for rel in "${AFFECTED_FILES[@]}"; do
-    local f="${REPO_ROOT}/${rel}"
-    if [[ ! -f "${f}" ]]; then
-      missing+=("${rel} (file not found)")
-      continue
-    fi
-    if ! grep -qF "codex exec --skip-git-repo-check -m gpt-5.2" "${f}"; then
-      missing+=("${rel}")
-    fi
-  done
-  if (( ${#missing[@]} > 0 )); then
-    printf 'Missing fixed invocation in:\n' >&2
-    printf '  %s\n' "${missing[@]}" >&2
-    return 1
-  fi
-}
-
-# ------------------------------------------------------------------
-# Per-file: no file may contain a bare invocation without -m gpt-5.2
-# ------------------------------------------------------------------
-
-@test "no affected file contains a bare 'codex exec --skip-git-repo-check' without -m gpt-5.2" {
-  local offenders=()
-  for rel in "${AFFECTED_FILES[@]}"; do
-    local f="${REPO_ROOT}/${rel}"
-    [[ -f "${f}" ]] || continue
-    # Lines that have the bare pattern but NOT the fixed pattern.
-    local bad
-    bad="$(grep -nF "codex exec --skip-git-repo-check" "${f}" \
-           | grep -vF "codex exec --skip-git-repo-check -m gpt-5.2" || true)"
-    if [[ -n "${bad}" ]]; then
-      offenders+=("${rel}:"$'\n'"${bad}")
-    fi
-  done
-  if (( ${#offenders[@]} > 0 )); then
-    printf 'Bare codex invocations (missing -m gpt-5.2):\n' >&2
-    printf '%s\n' "${offenders[@]}" >&2
-    return 1
-  fi
-}
-
-# ------------------------------------------------------------------
-# Repo-wide sweep: catches files newly added outside the scope list
-# ------------------------------------------------------------------
-
-@test "repo-wide: no 'codex exec --skip-git-repo-check' occurrence under my/ is missing -m gpt-5.2" {
+@test "no 'gpt-5' model reference anywhere under my/ (single-source policy)" {
   cd "${REPO_ROOT}"
   local bad
-  bad="$(grep -rnF "codex exec --skip-git-repo-check" my/ \
-         | grep -vF "codex exec --skip-git-repo-check -m gpt-5.2" || true)"
+  bad="$(grep -rn -- 'gpt-5' my/ || true)"
   if [[ -n "${bad}" ]]; then
-    printf 'Bare codex invocations found under my/:\n%s\n' "${bad}" >&2
+    printf 'Hard-wired Codex model reference found under my/:\n%s\n' "${bad}" >&2
     return 1
   fi
 }
 
 # ------------------------------------------------------------------
-# Idempotency: the fix must not have produced doubled -m flags
+# Belt-and-braces: no bare `-m <model>` pin on any codex invocation
 # ------------------------------------------------------------------
 
-@test "no doubled '-m gpt-5.2 -m gpt-5.2' anywhere under my/" {
+@test "no 'codex exec ... -m' model pin anywhere under my/" {
   cd "${REPO_ROOT}"
-  local dup
-  dup="$(grep -rnF -- "-m gpt-5.2 -m gpt-5.2" my/ || true)"
-  if [[ -n "${dup}" ]]; then
-    printf 'Doubled -m flag:\n%s\n' "${dup}" >&2
+  local bad
+  # Model-anchored so a multiline (backslash-continued) `-m gpt-5.4` or a future
+  # family (`-m claude-...`, `-m o4-...`) is caught even when `-m` is not on the
+  # same line as `codex exec`.
+  bad="$(grep -rnE -- '[[:space:]]-m[[:space:]]+(gpt|o[0-9]|claude|opus|gemini|sonnet|haiku)' my/ || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'Codex invocation with a hard-wired -m model pin found under my/:\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# Acceptance 2: no numeric Opus version pin anywhere under my/
+# ------------------------------------------------------------------
+
+@test "no numeric 'Opus N' version pin anywhere under my/" {
+  cd "${REPO_ROOT}"
+  local bad
+  # Any numeric Opus pin — Opus 4, Opus 4.8, Opus 5, opus-4-6 — not just 4.x.
+  # 'newest Opus' / 'model: opus' (no adjacent digit) stay allowed.
+  bad="$(grep -rniE -- 'opus[- ]?[0-9]' my/ || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'Hard-wired numeric Opus version pin found under my/:\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# Review gates must still be documented (no accidental deletion)
+# ------------------------------------------------------------------
+
+@test "at least one bare 'codex exec --skip-git-repo-check' invocation remains under my/" {
+  cd "${REPO_ROOT}"
+  local n
+  n="$(grep -rc -- 'codex exec --skip-git-repo-check' my/ | awk -F: '{s+=$2} END{print s+0}')"
+  if (( n == 0 )); then
+    printf 'Expected at least one documented codex review gate under my/, found none.\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# The single source of truth exists
+# ------------------------------------------------------------------
+
+@test "c-bpm-sk-llm-selection contains the Model Version Policy block" {
+  local f="${REPO_ROOT}/my/skills/c-bpm-sk-llm-selection/SKILL.md"
+  if [[ ! -f "${f}" ]]; then
+    printf 'c-bpm-sk-llm-selection/SKILL.md not found.\n' >&2
+    return 1
+  fi
+  if ! grep -qiF "Model Version Policy" "${f}"; then
+    printf 'Model Version Policy block missing from c-bpm-sk-llm-selection/SKILL.md.\n' >&2
     return 1
   fi
 }

--- a/tests/bash/c-bpm-sk-codex-invocation-hygiene.bats
+++ b/tests/bash/c-bpm-sk-codex-invocation-hygiene.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+#
+# c-bpm-sk-codex-invocation-hygiene.bats - Guard against Issue #94 regression
+# Run with: bats tests/bash/c-bpm-sk-codex-invocation-hygiene.bats
+#
+# Purpose:
+#   Issue #94: `codex exec` run from a login/rc-sourcing shell leaks profile
+#   startup output (keychain / ssh-agent / curl) into Codex's captured output,
+#   which Codex misreads as file content -> false-positive review verdicts.
+#   The canonical fix is a sanitized, non-login invocation documented ONCE in
+#   c-bpm-sk-llm-selection (the designated Codex authority). This suite locks in:
+#     1. The sanitized-invocation section exists with all sanitizing tokens.
+#     2. The section carries the #94 rationale.
+#     3. No file under my/ introduces a login-shell codex invocation.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+LLM_SELECTION="${REPO_ROOT}/my/skills/c-bpm-sk-llm-selection/SKILL.md"
+
+@test "c-bpm-sk-llm-selection exists" {
+  [[ -f "${LLM_SELECTION}" ]]
+}
+
+@test "canonical invocation carries all sanitizing tokens (--noprofile, --norc, BASH_ENV)" {
+  grep -qF -- "--noprofile" "${LLM_SELECTION}"
+  grep -qF -- "--norc" "${LLM_SELECTION}"
+  grep -qF -- "BASH_ENV" "${LLM_SELECTION}"
+}
+
+@test "canonical invocation documents the #94 leak rationale (keychain)" {
+  grep -qiF "keychain" "${LLM_SELECTION}"
+  grep -qF "#94" "${LLM_SELECTION}"
+}
+
+@test "no file under my/ invokes 'codex exec' from a login shell (bash -l / -lc)" {
+  cd "${REPO_ROOT}"
+  # An actual login-shell invocation has the login flag and 'codex exec' on the
+  # same command line. The prose in the hygiene section that *forbids* 'bash -lc'
+  # does not put 'codex exec' on that line, so it is not matched.
+  local bad
+  bad="$(grep -rnE "bash +-l[c ][^\\n]*codex exec" my/ || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'Login-shell codex invocation found under my/:\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}

--- a/tests/bash/c-bpm-sk-codex-review-loop.bats
+++ b/tests/bash/c-bpm-sk-codex-review-loop.bats
@@ -26,6 +26,9 @@ IN_SCOPE_FILES=(
   "my/skills/c-bpm-sk-skill-optimizer/SKILL.md"
   "my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md"
   "my/commands/c-bpm-cm-openissues-team.md"
+  # Issue #91: grill-claude-issue must stay consistent with the canonical loop
+  # (no deadlock/escalation clause; Producer revises until Codex verdict).
+  "my/skills/c-bpm-sk-grill-claude-issue/SKILL.md"
 )
 
 LLM_SELECTION="${REPO_ROOT}/my/skills/c-bpm-sk-llm-selection/SKILL.md"


### PR DESCRIPTION
Post-hoc **Codex Judge review: APPROVED** ("COMMIT + PUSH is justified").

## What
- **#98** — `c-bpm-sk-llm-selection` is the single source of truth for model selection. All `-m gpt-5.2` (Codex now follows CLI default) and numeric `Opus 4.6` teammate pins removed across ~24 skills/commands. New "Model Version Policy" block + sanitized canonical Codex invocation. Full call-site rollout of the sanitized form tracked in **#94**.
- **#91** — grill-claude-issue disagreement clause aligned with the no-cap / no-user-escalation / no-third-model Producer↔Codex loop (#89).
- **#66/#67** — CLAUDE.md hook example references the real `issue-write-gate` hook, corrected semantics, cited docs.

## Tests
Inverted the #44 codex-flag guard (model-anchored `-m` guard + generic numeric-Opus guard); added hygiene + hook-refs bats. Kept-cluster tests green. (9 pre-existing failures = #100 baseline, out of scope.)

## Verified
codex 0.128.0 default `gpt-5.4` works without `-m` under current auth → #44's pin reason no longer applies.

## Not included
Security-hook hardening (#69–84) was reverted for a properly-gated re-run — see #101 (plan-gate was not enforced this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)