### PR TITLE
Issue #104: anchor Issues-only communication into every c-bpm skill + command

### DIFF
--- a/my/commands/c-bpm-cm-library-compare.md
+++ b/my/commands/c-bpm-cm-library-compare.md
@@ -108,3 +108,16 @@ Based on the user's answer:
 - `nein`: Do nothing
 
 For content differences, always ask which version should win before overwriting.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/commands/c-bpm-cm-library-pull.md
+++ b/my/commands/c-bpm-cm-library-pull.md
@@ -19,3 +19,16 @@ After execution, summarise:
 - How many items were new, modified, unchanged
 - If `--dry-run` was used, note that no changes were made
 - If errors occurred, suggest fixes (e.g., "run `git pull` in the repo first")
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/commands/c-bpm-cm-openissues-list.md
+++ b/my/commands/c-bpm-cm-openissues-list.md
@@ -152,3 +152,16 @@ Milestones are available — assign them via GitHub or `/c-bpm-sk-milestone-type
 - It does NOT auto-assign milestones to individual issues — that's a Team Lead decision
 - **All data fetching uses `gh api` with `--jq`** — never GitHub MCP (too verbose)
 - **All GET requests use URL query params** — never `-f` flags (which trigger POST)
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/commands/c-bpm-cm-openissues-team.md
+++ b/my/commands/c-bpm-cm-openissues-team.md
@@ -339,3 +339,16 @@ After all workable issues are addressed:
 - File conflicts -> Team Lead resolves by reassigning scope
 - **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no model escalation needed
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to be set
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/commands/c-bpm-cm-refactor-repo.md
+++ b/my/commands/c-bpm-cm-refactor-repo.md
@@ -316,3 +316,16 @@ After all issues reach `test-approved`:
 - File conflicts → Team Lead resolves by reassigning scope
 - **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)** — no model escalation needed
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` to be set
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/commands/c-bpm-cm-skill-creator.md
+++ b/my/commands/c-bpm-cm-skill-creator.md
@@ -134,3 +134,16 @@ After real usage, the user may request improvements. At that point:
 ## Library Integration
 
 After creating a skill, use `c-bpm-cm-library-push` to sync it to the Git repository. See `c-bpm-sk-library-manager` skill for the full push/pull workflow and conventions for all artefact types (not just skills).
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/commands/c-bpm-cm-skill-optimizer.md
+++ b/my/commands/c-bpm-cm-skill-optimizer.md
@@ -168,3 +168,16 @@ After creating or optimizing a skill, use `c-bpm-cm-library-push` to sync it to 
 
 ### `references/team-orchestration.md`
 Read when: orchestrating a team to build or refactor multiple skills in parallel, setting up milestone-based issue tracking for skill development, spawning and coordinating agent teammates, running Codex review gates, or managing the full development lifecycle from discovery through PR synthesis.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/shared/issue-communication-protocol.md
+++ b/my/shared/issue-communication-protocol.md
@@ -1,26 +1,3 @@
----
-name: c-bpm-cm-library-push
-description: "Push skills to repo — push to repo, upload skills, save skills, publish skills. Syncs c-bpm items from local ~/.claude/ to Git repo. Auto-commits and pushes."
-allowed-tools: Bash
-argument-hint: "[--dry-run] [--force] [--clean] [--message msg] [--only-skills] [--verbose]"
----
-
-# /c-bpm-cm-library-push — Push my-items from local to repo
-
-Run the `c-bpm-cm-library-push` command to synchronise custom `my-` items from the local `~/.claude/` directory to the Git repository.
-
-Pass any arguments the user provided via `$ARGUMENTS`.
-
-```bash
-c-bpm-cm-library-push $ARGUMENTS
-```
-
-After execution, summarise:
-- How many items were new, modified, unchanged
-- If items exist in the repo but not locally, mention them (manual cleanup needed)
-- If `--dry-run` was used, note that no changes were made
-- If errors occurred, suggest fixes
-
 <!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
 ## Communication: GitHub Issues only
 

--- a/my/skills/c-bpm-sk-api-contract/SKILL.md
+++ b/my/skills/c-bpm-sk-api-contract/SKILL.md
@@ -54,3 +54,16 @@ HTTP/1.1 200 OK
 - Lack of pagination causing huge responses
 - Unstructured error messages
 - Breaking changes without versioning
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-appsec-threatlite/SKILL.md
+++ b/my/skills/c-bpm-sk-appsec-threatlite/SKILL.md
@@ -76,3 +76,16 @@ Track findings to closure — document vulnerabilities, assign to implementers, 
 - Extracting archives without verifying file paths
 - Running scripts as root when not necessary
 - Ignoring dependency vulnerabilities
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-auditor/SKILL.md
+++ b/my/skills/c-bpm-sk-auditor/SKILL.md
@@ -181,3 +181,16 @@ Write `[REPONAME]-YYMMDD-HHSS.md`, send shutdown_request to all teammates, TeamD
 - If tests require credentials/DB → note as "unable to verify" in report
 - If repo is too large for single pass → ask user to scope the audit
 - Codex unavailable → try fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: notify user, do not proceed without independent review. Log which reviewer was used.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-bash-secure-script/SKILL.md
+++ b/my/skills/c-bpm-sk-bash-secure-script/SKILL.md
@@ -57,3 +57,16 @@ main "$@"
 - Unquoted variables causing word splitting or globbing
 - Failure to handle errors from external commands
 - Temporary files left behind
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-bootstrap-ui/SKILL.md
+++ b/my/skills/c-bpm-sk-bootstrap-ui/SKILL.md
@@ -55,3 +55,16 @@ Guidance for building user interfaces with Bootstrap, focusing on consistent sty
 - Mixing custom styles with Bootstrap causing conflicts
 - Ignoring accessibility attributes (aria labels, roles)
 - Fixed widths or absolute positioning breaking responsiveness
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-config-secrets/SKILL.md
+++ b/my/skills/c-bpm-sk-config-secrets/SKILL.md
@@ -56,3 +56,16 @@ foreach (file('.env', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
 - Committing `.env` to version control
 - Loading `.env` multiple times causing overrides
 - Weak file permissions allowing other users to read secrets
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-curlbash-installer/SKILL.md
+++ b/my/skills/c-bpm-sk-curlbash-installer/SKILL.md
@@ -189,3 +189,16 @@ Read when: you need a complete copy-paste-ready example of mytool + install.sh t
 - **Using commit timestamp for dirty** — uncommitted code has no commit; use `date`
 - **Wrong variable name in `sed`** — must match the exact variable in the script
 - **`stamp_version` on sudo-owned file** — may need `sudo sed` for global installs
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-datatables/SKILL.md
+++ b/my/skills/c-bpm-sk-datatables/SKILL.md
@@ -47,3 +47,16 @@ $('#users-table').DataTable({
 - Loading all data client-side causing performance issues
 - Failing to escape HTML causing XSS
 - Inconsistent column ordering or missing keys
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-flightphp-pro/SKILL.md
+++ b/my/skills/c-bpm-sk-flightphp-pro/SKILL.md
@@ -214,3 +214,16 @@ Read when: implementing CSRF protection, XSS prevention, SQL injection preventio
 
 ### `references/team-orchestration.md`
 Read when: orchestrating a team to build or refactor a Flight PHP project, setting up milestone-based issue tracking, spawning and coordinating agent teammates, running Codex review gates, or managing the full development lifecycle from discovery through PR synthesis.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-grill-claude-issue/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-claude-issue/SKILL.md
@@ -223,3 +223,16 @@ immediately — do not retry the failed tool on subsequent rounds.
 - Do NOT run dedup checks (MVP scope — deferred)
 - If a question can be answered by reading code, read the code before answering
 - Track question and follow-up budgets strictly — stop when exhausted
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-grill-me-issue/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-me-issue/SKILL.md
@@ -180,3 +180,16 @@ Both paths execute the full wrap-up protocol.
 - Never modify labels or milestone without asking the user first
 - Keep the original issue body intact — append refined sections below it
 - Track all created issues to avoid exceeding the 3-per-session limit
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-grill-me/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-me/SKILL.md
@@ -189,3 +189,16 @@ When all branches are resolved (or stop signal received):
 
 5. **Codex Fallback Chain** — if `codex` is unavailable, try `gemini`. If both
    fail, notify the user that the Devil's Advocate review must be done manually.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-idea-merge/SKILL.md
+++ b/my/skills/c-bpm-sk-idea-merge/SKILL.md
@@ -170,3 +170,16 @@ gh issue comment {number} --body "..." -R {owner}/{repo}
 6. **Codex approval required** — no mutations without Codex review (fallback chain applies)
 7. **Dry-run first** — always show the diff before executing
 8. **Idempotent** — running the scan again after execution should show no new clusters for already-processed items
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-jquery-ajax-forms/SKILL.md
+++ b/my/skills/c-bpm-sk-jquery-ajax-forms/SKILL.md
@@ -53,3 +53,16 @@ $('#myForm').on('submit', function(e) {
 - Ignoring CSRF tokens causing security vulnerabilities
 - No error feedback leaving users confused
 - Multiple submissions due to missing button disabling
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-library-manager/SKILL.md
+++ b/my/skills/c-bpm-sk-library-manager/SKILL.md
@@ -118,3 +118,16 @@ User wants to create something new?
 - `c-bpm-cm-library-push` pulls first, then pushes — detects conflicts early
 - Deleted items: shown as warnings, **never auto-deleted** (safety)
 - Resolution: manual `cd ~/bpm-claude-global-agent-skill-library && git status`
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-linux-admin/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-admin/SKILL.md
@@ -363,3 +363,16 @@ See `c-bpm-sk-milestone-type` for full milestone definitions and transition rule
 - Communication via shared task list and messages
 - **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)**
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-linux-archive/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-archive/SKILL.md
@@ -174,3 +174,16 @@ If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI)
 - MUST NOT store binaries in the repo — only configs and manifests
 - MUST update `installed-tools.md` with every new tool
 - MUST update MEMORY.md installed-tools table
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-linux-audit/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-audit/SKILL.md
@@ -314,3 +314,16 @@ If ALL models in the chain are unavailable:
 - Communication via shared task list and messages
 - **All teammates use newest Opus (see `c-bpm-sk-llm-selection`)**
 - Agent teams require: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-llm-selection/SKILL.md
+++ b/my/skills/c-bpm-sk-llm-selection/SKILL.md
@@ -205,3 +205,16 @@ All implementers MUST rely on Orchestrator handoffs and may not probe MCP server
 - Inviting a third model alongside Codex to break a tie
 - Running Gemini (or any non-Codex Judge) as a co-Judge or second opinion while Codex is reachable
 - Not checking LLM availability before assignment
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-mariadb-migrations/SKILL.md
+++ b/my/skills/c-bpm-sk-mariadb-migrations/SKILL.md
@@ -43,3 +43,16 @@ UPDATE users SET email = CONCAT(username, '@example.com') WHERE email IS NULL;
 - Non-idempotent migrations causing repeated column additions
 - Manual schema changes outside of migrations
 - Lack of documentation during deployment
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-milestone-type/SKILL.md
+++ b/my/skills/c-bpm-sk-milestone-type/SKILL.md
@@ -276,3 +276,16 @@ gh api repos/{owner}/{repo}/milestones --jq '.[] | "\(.number) \(.title)"'
 ## Supersedes
 
 This skill replaces `c-bpm-sk-team-milestones`. All references to the old skill should use this one instead.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-n8n-reliability/SKILL.md
+++ b/my/skills/c-bpm-sk-n8n-reliability/SKILL.md
@@ -50,3 +50,16 @@ Ensure n8n workflows are reliable, maintainable and easy to version with pattern
 - Hardcoded credentials or environment details in nodes
 - Lack of error handling leading to lost data
 - Unversioned workflows causing rollback confusion
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-php-crud-api-review/SKILL.md
+++ b/my/skills/c-bpm-sk-php-crud-api-review/SKILL.md
@@ -42,3 +42,16 @@ GET /api.php/users?limit=10&filter=id,gt,100
 - Exposing entire databases without restrictions
 - Missing primary keys causing misbehaviour
 - No authentication leading to unauthorised access
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-php-flight-mvc/SKILL.md
+++ b/my/skills/c-bpm-sk-php-flight-mvc/SKILL.md
@@ -56,3 +56,16 @@ class HomeController {
 - Fat controllers mixing routing and business logic
 - Tight coupling between controllers and database
 - Lack of autoloading and PSR compliance
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-question-auditor/SKILL.md
+++ b/my/skills/c-bpm-sk-question-auditor/SKILL.md
@@ -187,3 +187,16 @@ Every finding row MUST include the **question UUID** and **answer UUID** for dir
 
 - `references/edums3-api.md` — API endpoints, curl commands, response structure
 - `references/report-template.md` — Full report Markdown template
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-redis-keyspace/SKILL.md
+++ b/my/skills/c-bpm-sk-redis-keyspace/SKILL.md
@@ -43,3 +43,16 @@ fi
 - Generic key names that collide with other applications
 - Missing TTLs leading to memory bloat
 - Locks never released due to missing expiry or ownership checks
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-release-ops/SKILL.md
+++ b/my/skills/c-bpm-sk-release-ops/SKILL.md
@@ -71,3 +71,16 @@ If Codex is unavailable: STOP and notify the user.
 - Missing changelog or release notes
 - Manual deployments leading to human error
 - No rollback plan causing extended downtime
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-repo-scaffold/SKILL.md
+++ b/my/skills/c-bpm-sk-repo-scaffold/SKILL.md
@@ -65,3 +65,16 @@ If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI)
 - Missing or inconsistent directories
 - Lack of README or minimal description
 - Ignoring files that should be committed
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-skill-creator/SKILL.md
+++ b/my/skills/c-bpm-sk-skill-creator/SKILL.md
@@ -170,3 +170,16 @@ skill directly.
 ## Library Integration
 
 After creating a skill, use `c-bpm-cm-library-push` to sync to Git.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-skill-optimizer/SKILL.md
+++ b/my/skills/c-bpm-sk-skill-optimizer/SKILL.md
@@ -173,3 +173,16 @@ After optimizing a skill, use `c-bpm-cm-library-push` to sync to Git.
 Read when: orchestrating a team to build or refactor multiple skills in parallel,
 setting up milestone-based issue tracking, spawning agent teammates, running
 Codex review gates, or managing the full lifecycle from discovery through PR.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-test-harness/SKILL.md
+++ b/my/skills/c-bpm-sk-test-harness/SKILL.md
@@ -54,3 +54,16 @@ public function testHomePageReturns200(): void {
 - Tests depending on external service state without mocking
 - Tests leaving artefacts or open connections
 - Missing negative tests causing unhandled production errors
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-tls-http-headers/SKILL.md
+++ b/my/skills/c-bpm-sk-tls-http-headers/SKILL.md
@@ -50,3 +50,16 @@ add_header Permissions-Policy "geolocation=(), microphone=()";
 - Overly permissive or missing CSP
 - Failing to renew certificates
 - Wildcard CORS without restrictions
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/scripts/stamp-issue-protocol.sh
+++ b/scripts/stamp-issue-protocol.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# stamp-issue-protocol.sh — stamp the canonical "Communication: GitHub Issues only"
+# block (my/shared/issue-communication-protocol.md) into every c-bpm skill and
+# command. Single source of truth -> stamped into all -> zero drift (Issue #104).
+# Idempotent: re-running produces byte-identical files. Enforced by
+# tests/bash/issue-comms-anchor.bats.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MASTER="${ROOT}/my/shared/issue-communication-protocol.md"
+[[ -f "${MASTER}" ]] || { echo "ERROR: master not found: ${MASTER}" >&2; exit 1; }
+BLOCK="$(cat "${MASTER}")"
+
+shopt -s nullglob
+targets=( "${ROOT}"/my/skills/c-bpm-sk-*/SKILL.md "${ROOT}"/my/commands/c-bpm-cm-*.md )
+(( ${#targets[@]} > 0 )) || { echo "ERROR: no target skills/commands found" >&2; exit 1; }
+
+n=0
+for f in "${targets[@]}"; do
+  tmp="$(mktemp "${f}.stampXXXXXX")"
+  # Drop any existing block (BEGIN..END inclusive), then drop trailing blank lines.
+  awk '
+    /<!-- BEGIN issue-comms/ { skip=1 }
+    skip!=1 { print }
+    /<!-- END issue-comms/   { skip=0 }
+  ' "${f}" | awk '
+    { lines[NR]=$0 }
+    END { last=NR; while (last>0 && lines[last] ~ /^[[:space:]]*$/) last--; for(i=1;i<=last;i++) print lines[i] }
+  ' > "${tmp}"
+  # Re-append the canonical block, separated by exactly one blank line.
+  printf '\n%s\n' "${BLOCK}" >> "${tmp}"
+  mv "${tmp}" "${f}"
+  n=$((n + 1))
+done
+
+echo "stamped issue-comms block into ${n} files"

--- a/tests/bash/issue-comms-anchor.bats
+++ b/tests/bash/issue-comms-anchor.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# issue-comms-anchor.bats — CI drift-guard for Issue #104.
+# Every c-bpm skill and command MUST carry the canonical "Communication: GitHub
+# Issues only" block, byte-identical to the master. Fails on absence or drift.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  MASTER="${REPO_ROOT}/my/shared/issue-communication-protocol.md"
+}
+
+# Extract the BEGIN..END block (inclusive) from a file.
+extract_block() {
+  awk '
+    /<!-- BEGIN issue-comms/ { p=1 }
+    p { print }
+    /<!-- END issue-comms/   { p=0 }
+  ' "$1"
+}
+
+@test "master issue-communication-protocol.md exists" {
+  [ -f "${MASTER}" ]
+}
+
+@test "every c-bpm skill + command carries the canonical block, byte-identical to master" {
+  local master_block bad=0
+  master_block="$(extract_block "${MASTER}")"
+  [ -n "${master_block}" ]
+
+  shopt -s nullglob
+  local targets=( "${REPO_ROOT}"/my/skills/c-bpm-sk-*/SKILL.md "${REPO_ROOT}"/my/commands/c-bpm-cm-*.md )
+  [ "${#targets[@]}" -gt 0 ]
+
+  for f in "${targets[@]}"; do
+    local block
+    block="$(extract_block "${f}")"
+    if [ "${block}" != "${master_block}" ]; then
+      printf 'DRIFT/MISSING issue-comms block in: %s\n' "${f#${REPO_ROOT}/}" >&2
+      bad=1
+    fi
+  done
+  [ "${bad}" -eq 0 ]
+}


### PR DESCRIPTION
Bakes the 'everything communicates via GitHub Issues — no side-car MD files' rule into the skills themselves (single master block stamped into all 40 c-bpm skills+commands), with an idempotent stamper and a CI byte-drift guard. Codex Judge: plan v2 + implementation APPROVED (reviewed by reading Issue #104 via REST — dogfooding). Runtime hard-block deferred to #105. Delivers #58/#59.

Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)