### PR TITLE
Issue #101: make the SoD gate a capability, not a rule

### DIFF
--- a/my/agents/c-bpm-ag-teammate.md
+++ b/my/agents/c-bpm-ag-teammate.md
@@ -1,0 +1,51 @@
+---
+name: c-bpm-ag-teammate
+description: Restricted implementation teammate for /c-bpm-cm-openissues-team and /c-bpm-cm-refactor-repo. Writes code only. Has no shell, so it cannot invoke Codex, mutate GitHub, or push — the Team Lead is the sole gate of record.
+tools: Read, Write, Edit, Glob, Grep
+---
+
+# Agent: Restricted Teammate
+
+Implements a scoped change against an Issue whose body and comments the Team Lead pastes
+into the spawn prompt. Spawned with `isolation: "worktree"`, so edits never reach the
+shared tree until the Lead merges them behind a passed Codex gate.
+
+## Why this agent has no `Bash`
+
+The Segregation-of-Duty gate was previously **policy**: teammates held full tools and were
+merely instructed not to run `codex exec`, not to self-approve, and not to edit before
+plan-approval. The instruction was contradicted by the tooling itself — the PostToolUse
+hook ordered every agent to "Run codex exec to review" after every file write (#101).
+
+Withholding `Bash` makes the forbidden actions **impossible** rather than forbidden:
+
+| Forbidden action | Needs | Available here |
+|---|---|---|
+| `codex exec` (forge a verdict) | Bash | no |
+| `gh issue comment` / milestone / label writes | Bash | no |
+| `git push` | Bash | no |
+| Run the test suite and self-report green | Bash | no |
+
+A verdict this agent cannot produce is a verdict it cannot forge.
+
+## Responsibilities
+
+- Read the Issue content supplied in the prompt. Do not attempt to fetch it — there is no network.
+- Submit a plan (files, changes, test coverage, risk, rollback) and wait for approval.
+- After approval, edit only the files named in the plan; write the tests the plan promised.
+- Report what changed, in prose, back to the Team Lead.
+
+## What your report is, and is not
+
+Your report is **narrative, never state**. Saying "tests pass" or "Codex approved" moves
+nothing: the Team Lead runs the suite, runs Codex, and posts the `## GATE` comment carrying
+a nonce only the Lead can generate. Report honestly and let the Lead verify — an unverified
+claim from you is worth less than an accurate account of what you could not check.
+
+If you find you need a command run (a build step, a test), say so and ask the Lead to run
+it. Do not treat the missing shell as an obstacle to route around; it is the control.
+
+## Findings
+
+Anything you discover outside your scope — a bug, a gap, a suspect design — goes into your
+report to the Lead, who files it as an Issue. You cannot file it yourself.

--- a/my/commands/c-bpm-cm-openissues-team.md
+++ b/my/commands/c-bpm-cm-openissues-team.md
@@ -166,21 +166,57 @@ Before spawning, review ALL available skills (`/skills` or check `~/.claude/skil
 
 Include the relevant skill names in each teammate's spawn prompt so they can leverage specialized knowledge.
 
-### Spawn Instructions per Teammate
-Each teammate MUST receive:
+### Spawn Form (the ONLY permitted form)
+Every teammate is spawned as:
+
+```
+subagent_type: c-bpm-ag-teammate
+isolation: "worktree"
+mode: "plan"
+```
+
+There is no second spawn path. An unrestricted teammate — one holding `Bash`, `gh`, or a
+shared working tree — must not be created for any reason, however urgent the task.
+
+**Why, and what each part buys (see #101):**
+- `c-bpm-ag-teammate` grants `Read, Write, Edit, Glob, Grep` and **no `Bash`**. The teammate
+  therefore *cannot* run `codex exec`, *cannot* run `gh`, *cannot* `git push`. The SoD gate
+  stops being a rule the teammate is asked to obey and becomes a capability it does not have.
+- `isolation: "worktree"` keeps every edit in the teammate's own worktree. Nothing reaches
+  the shared tree until the Team Lead merges it behind a **passed** Codex gate. This is what
+  prevents the #101 failure where Codex-REJECTED code was already sitting in the tree.
+- `mode: "plan"` remains, but is now a convenience, **not** the control. It failed to block
+  Edit/Write in practice; do not rely on it.
+
+### Gate of Record — Lead only
+**A teammate's report is narrative, never state.** A teammate writing "Codex approved",
+"tests pass", or "plan accepted" advances *nothing*. Only the Team Lead advances state, and
+only on facts the Lead observed itself:
+
+| Fact | Who establishes it |
+|---|---|
+| Codex verdict | Team Lead runs `codex exec`, reads raw stdout |
+| Test result | Team Lead runs `./tests/run_tests.sh` |
+| Milestone / label / comment | Team Lead via `gh` |
+
+Every Codex verdict is posted as a `## GATE` comment carrying a **nonce the Lead generated**
+(`NONCE=$(openssl rand -hex 8)`) before that Codex run. A gate verdict whose nonce the Lead
+did not generate is **void**, however convincing it reads. No phase transition in this
+command may be predicated on teammate-reported approval.
+
+### Spawn Prompt Contents
+Each teammate MUST receive, pasted into the prompt (it has no `gh` and no network):
+- The **Issue body and comments**, fetched by the Lead:
+  `gh api repos/<owner>/<repo>/issues/<n> --jq .body` and `.../issues/<n>/comments`
 - Clear scope: exact file paths they may modify
 - Explicit boundaries: files they must NOT touch
-- List of GitHub Issue numbers they own
 - **Relevant skills** to use for their assigned work (from the list above)
-- Instruction: **Submit a PLAN to team-lead BEFORE writing ANY code**
+- Instruction: **Submit a PLAN before writing ANY code**
 - Instruction: **Plan MUST include test coverage** or it will be auto-rejected
-- Instruction: **Do NOT commit** — automation handles commits
 - Instruction: Follow `set -euo pipefail` safety (avoid `((var++))` with var=0)
-- Instruction: Run `./tests/run_tests.sh` after changes to verify nothing breaks
+- Instruction: **Write the tests; do not run them.** You have no shell. Report what you
+  changed; the Team Lead runs the suite and Codex. Ask the Lead if you need a command run.
 - The project's CLAUDE.md rules and SoD workflow
-
-### Plan Mode
-All teammates MUST be spawned with `mode: "plan"` so they require plan approval before making any changes.
 
 ### Milestone: Set `planned`
 Team Lead sets milestone `planned` on each assigned issue before spawning teammates.

--- a/my/commands/c-bpm-cm-refactor-repo.md
+++ b/my/commands/c-bpm-cm-refactor-repo.md
@@ -152,14 +152,39 @@ WAIT for user confirmation before creating the team.
 ### Teammate Naming
 Descriptive role names: `security-hardener`, `test-writer`, `code-cleaner`, `dep-updater`, `doc-improver`, `arch-refactorer`
 
-### Spawn Instructions per Teammate
+### Spawn Form (the ONLY permitted form)
+Every teammate is spawned as:
+
+```
+subagent_type: c-bpm-ag-teammate
+isolation: "worktree"
+mode: "plan"
+```
+
+There is no second spawn path. An unrestricted teammate — one holding `Bash`, `gh`, or a
+shared working tree — must not be created for any reason, however urgent the task.
+`c-bpm-ag-teammate` has **no `Bash`**: it cannot run `codex exec`, cannot run `gh`, cannot
+`git push`. The SoD gate is a capability the teammate lacks, not a rule it is asked to obey
+(see #101). `mode: "plan"` remains a convenience, **not** the control — it demonstrably
+failed to block Edit/Write.
+
+### Gate of Record — Lead only
+**A teammate's report is narrative, never state.** "Codex approved", "tests pass" and
+"plan accepted" from a teammate advance *nothing*. The Team Lead runs `codex exec`, runs
+the test suite, and performs every `gh` mutation itself, and posts each verdict as a
+`## GATE` comment carrying a **nonce the Lead generated** (`NONCE=$(openssl rand -hex 8)`)
+before that Codex run. A verdict whose nonce the Lead did not generate is **void**.
+
+### Spawn Prompt Contents
+Each teammate MUST receive, pasted into the prompt (it has no `gh` and no network):
+- The **Issue body and comments**, fetched by the Lead via `gh api`
 - Clear scope (which files/modules they own)
 - Explicit boundaries (what they must NOT touch)
-- List of GitHub Issue numbers they are responsible for
 - Expected deliverables
-- Which MCP servers to use (if relevant)
 - **Relevant skills** to use for their assigned work (from the list below)
 - Instruction: send PLAN to team-lead BEFORE writing any code
+- Instruction: **write the tests; do not run them** — you have no shell. The Team Lead runs
+  the suite and Codex. Ask the Lead if you need a command run.
 
 ### Skill Selection per Teammate
 Before spawning, review ALL available skills (`/skills` or check `~/.claude/skills/` and `.claude/skills/`). Assign relevant skills to each teammate based on their task:

--- a/my/hooks/codex-sod-tracker.sh
+++ b/my/hooks/codex-sod-tracker.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Codex Segregation of Duty Tracker — Global Hook
+# Enforces: Codex review on all changes + Milestone/Type compliance
+# =============================================================================
+
+TRACK_DIR="/tmp/claude-codex-sod"
+mkdir -p "$TRACK_DIR" 2>/dev/null || true
+
+TRACK_FILE="${TRACK_DIR}/changed_files.log"
+REVIEW_FILE="${TRACK_DIR}/reviewed_files.log"
+
+EVENT="${1:-unknown}"
+
+case "$EVENT" in
+    SESSION_START)
+        : > "$TRACK_FILE" 2>/dev/null || true
+        : > "$REVIEW_FILE" 2>/dev/null || true
+        cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"ABSOLUTE MANDATORY RULES — VIOLATION IS FORBIDDEN:\n\n== SEGREGATION OF DUTY ==\n1. Team Lead NEVER edits files directly. Use /c-bpm-cm-openissues-team ALWAYS.\n2. The reviewer is invoked by the TEAM LEAD ONLY, and never by a teammate. If you were spawned as a teammate, you have no shell and no reviewer: write the code, report honestly, and let the Lead verify. A teammate that claims a review verdict is fabricating one.\n3. The reviewer is the PRIMARY review authority. Team Lead approves alone is FORBIDDEN.\n4. Every file change is reviewed by the Team Lead before it lands.\n5. A teammate report is NARRATIVE, NEVER STATE. Only a Lead-posted GATE comment carrying a Lead-generated nonce advances a milestone.\n6. Post ALL review results as GitHub Issue comments.\n7. Use docker exec (not docker run) for container commands.\n\n== MILESTONE + TYPE (c-bpm-sk-milestone-type) ==\n8. EVERY issue MUST have exactly ONE milestone and ONE type label (bug or enhancement).\n9. Run /c-bpm-cm-openissues-list before any issue work to verify compliance.\n10. Update milestones at EVERY phase transition.\n11. DONE is HUMAN-ONLY — agents NEVER set DONE.\n\nTHESE RULES ARE NON-NEGOTIABLE."}}
+EOF
+        ;;
+
+    POST_EDIT)
+        INPUT="$(cat 2>/dev/null || echo '{}')"
+        FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_response.filePath // "unknown"' 2>/dev/null || echo 'unknown')"
+        echo "$FILE_PATH" >> "$TRACK_FILE" 2>/dev/null || true
+        UNREVIEWED="$(sort -u "$TRACK_FILE" 2>/dev/null | wc -l)"
+        REVIEWED="$(sort -u "$REVIEW_FILE" 2>/dev/null | wc -l)"
+        PENDING=$((UNREVIEWED - REVIEWED))
+        test "$PENDING" -lt 0 && PENDING=0
+        # Telemetry only. This text is injected into EVERY agent, including restricted
+        # teammates that must never invoke the reviewer (#101). It therefore states a
+        # fact and issues no instruction — the Team Lead is the sole gate of record.
+        printf '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"FILE CHANGED: %s — %d file(s) pending Team Lead review."}}\n' "$FILE_PATH" "$PENDING"
+        ;;
+
+    POST_BASH)
+        INPUT="$(cat 2>/dev/null || echo '{}')"
+        CMD="$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || echo '')"
+        if echo "$CMD" | grep -q "codex exec" 2>/dev/null; then
+            cat "$TRACK_FILE" >> "$REVIEW_FILE" 2>/dev/null || true
+        fi
+        echo '{}'
+        ;;
+
+    STOP)
+        if [ -f "$TRACK_FILE" ]; then
+            CHANGED="$(sort -u "$TRACK_FILE" 2>/dev/null | wc -l)"
+            REVIEWED="$(sort -u "$REVIEW_FILE" 2>/dev/null | wc -l)"
+            PENDING=$((CHANGED - REVIEWED))
+            test "$PENDING" -lt 0 && PENDING=0
+            if [ "$PENDING" -gt 0 ]; then
+                FILES="$(comm -23 <(sort -u "$TRACK_FILE") <(sort -u "$REVIEW_FILE") 2>/dev/null | tr '\n' ' ')"
+                printf '{"systemMessage":"WARNING: %d file(s) changed without Codex review: %s"}\n' "$PENDING" "$FILES"
+            else
+                echo '{"systemMessage":"All changes Codex-reviewed. SoD compliant."}'
+            fi
+            rm -rf "$TRACK_DIR" 2>/dev/null || true
+        else
+            echo '{}'
+        fi
+        ;;
+
+    *)
+        echo '{}' ;;
+esac
+exit 0

--- a/tests/bash/c-bpm-sod-capability.bats
+++ b/tests/bash/c-bpm-sod-capability.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# c-bpm-sod-capability.bats — regression guard for Issue #101.
+#
+# The SoD gate must be a CAPABILITY the teammate lacks, not a RULE it is asked to
+# obey. Three things must hold, forever:
+#   1. The PostToolUse hook must not order any agent to run the reviewer.
+#   2. The teammate agent must not hold a shell.
+#   3. The team command must have exactly one spawn path, and must never treat a
+#      teammate's word as state.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  HOOK="${REPO_ROOT}/my/hooks/codex-sod-tracker.sh"
+  AGENT="${REPO_ROOT}/my/agents/c-bpm-ag-teammate.md"
+  CMD="${REPO_ROOT}/my/commands/c-bpm-cm-openissues-team.md"
+  REFACTOR="${REPO_ROOT}/my/commands/c-bpm-cm-refactor-repo.md"
+}
+
+# The `tools:` line of the agent frontmatter, or empty if absent.
+agent_tools_line() {
+  awk '/^---$/{n++; next} n==1 && /^tools:/{print; exit}' "${AGENT}"
+}
+
+# --- 1. the hook must not issue the forbidden order -------------------------
+
+@test "hook exists in the library (not only on one host)" {
+  [ -f "${HOOK}" ]
+  [ -x "${HOOK}" ]
+}
+
+@test "POST_EDIT context contains no instruction to run the reviewer" {
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"/x/y.sh\"}}" | "$1" POST_EDIT' _ "${HOOK}"
+  [ "$status" -eq 0 ]
+  # This is the #101 regression: the hook told every agent, teammates included,
+  # to run codex exec after every write.
+  [[ "$output" != *"codex exec"* ]]
+  [[ "$output" != *"MANDATORY"* ]]
+  [[ "$output" != *"Run codex"* ]]
+}
+
+@test "POST_EDIT still emits valid JSON naming the changed file" {
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"/x/y.sh\"}}" | "$1" POST_EDIT' _ "${HOOK}"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "PostToolUse"'
+  echo "$output" | jq -e '.hookSpecificOutput.additionalContext | contains("/x/y.sh")'
+}
+
+@test "SessionStart rules do not order any agent to invoke the reviewer themselves" {
+  run bash -c '"$1" SESSION_START' _ "${HOOK}"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"'
+  ctx="$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')"
+  # SessionStart is injected into EVERY agent session, teammates included. The old
+  # rule 2 read "EVERY file change MUST be reviewed via: codex exec --skip-git-repo-check"
+  # — a command, handed to the one party that must never run it.
+  [[ "$ctx" != *"codex exec"* ]]
+  [[ "$ctx" != *"--skip-git-repo-check"* ]]
+}
+
+@test "SessionStart names the Lead as sole invoker and teammate reports as non-state" {
+  run bash -c '"$1" SESSION_START' _ "${HOOK}"
+  ctx="$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')"
+  [[ "$ctx" == *"TEAM LEAD ONLY"* ]]
+  [[ "$ctx" == *"NARRATIVE, NEVER STATE"* ]]
+}
+
+@test "installed hook on this host matches the library copy (no local drift)" {
+  # The imperative lived in ~/.claude/hooks; a library-only fix would leave it firing.
+  if [ ! -f "${HOME}/.claude/hooks/codex-sod-tracker.sh" ]; then skip "hook not installed on this host"; fi
+  run diff -q "${HOME}/.claude/hooks/codex-sod-tracker.sh" "${HOOK}"
+  [ "$status" -eq 0 ]
+}
+
+# --- 2. the teammate must not hold a shell ----------------------------------
+
+@test "c-bpm-ag-teammate agent definition exists with a tools: allowlist" {
+  [ -f "${AGENT}" ]
+  [ -n "$(agent_tools_line)" ]
+}
+
+@test "teammate tools: grants no Bash — codex exec, gh and git push are impossible" {
+  line="$(agent_tools_line)"
+  # Anchored on the tools: line only. Substring-matching the whole file is the
+  # prose-vs-thing bug that produced three false-positive detectors (#97, #90).
+  [[ "$line" != *"Bash"* ]]
+  [[ "$line" != *"Task"* ]]
+  [[ "$line" != *"Teammate"* ]]
+}
+
+@test "teammate tools: still grants what implementation actually needs" {
+  line="$(agent_tools_line)"
+  [[ "$line" == *"Read"* ]]
+  [[ "$line" == *"Edit"* ]]
+  [[ "$line" == *"Write"* ]]
+}
+
+# --- 3. one spawn path; teammate words are not state -------------------------
+
+@test "every teammate-spawning command spawns the restricted agent in a worktree" {
+  # Both commands, not just the one #101 was filed against: a single clean path is
+  # worthless while a second capability path stays reachable.
+  for c in "${CMD}" "${REFACTOR}"; do
+    grep -q 'subagent_type: c-bpm-ag-teammate' "$c" || { echo "no restricted spawn in $c"; return 1; }
+    grep -q 'isolation: "worktree"' "$c"            || { echo "no worktree isolation in $c"; return 1; }
+  done
+}
+
+@test "every teammate-spawning command declares the Lead the sole gate of record" {
+  for c in "${CMD}" "${REFACTOR}"; do
+    grep -qi 'narrative, never state' "$c" || { echo "no gate-of-record clause in $c"; return 1; }
+    grep -qi 'nonce' "$c"                  || { echo "no nonce requirement in $c"; return 1; }
+  done
+}
+
+@test "no command keeps an unrestricted spawn path to fall back into" {
+  # Rollback must be `git revert`, not "use the old path" (Codex plan-gate #3).
+  for c in "${CMD}" "${REFACTOR}"; do
+    n="$(grep -c 'subagent_type:' "$c")"
+    [ "$n" -eq 1 ] || { echo "$c declares $n spawn paths, want exactly 1"; return 1; }
+  done
+}


### PR DESCRIPTION
Closes #101.

The gate was **policy, not capability**: teammates held full tools and were merely *instructed* not to invoke the reviewer, not to self-approve, and not to edit before plan-approval — while `codex-sod-tracker.sh` injected, into every agent after every file write:

> FILE CHANGED — Codex review MANDATORY. Run `codex exec` to review.

The tooling issued the forbidden order, to the forbidden party, at the moment of maximum temptation.

## Changes

| File | Change |
|---|---|
| `my/agents/c-bpm-ag-teammate.md` (new) | `tools: Read, Write, Edit, Glob, Grep` — **no `Bash`**. `codex exec`, `gh` and `git push` are unreachable. |
| `my/commands/c-bpm-cm-openissues-team.md` | One spawn form only: restricted agent + `isolation: "worktree"`. Gate-of-record clause. |
| `my/commands/c-bpm-cm-refactor-repo.md` | Same — the second capability path, caught by the Codex REJECT. |
| `my/hooks/codex-sod-tracker.sh` | Imperative removed at **both** layers (`POST_EDIT` → telemetry, `SESSION_START` → reviewer is Team-Lead-only). Now versioned in the library, not host-local. |
| `tests/bash/c-bpm-sod-capability.bats` (new) | 12 tests, **proven failable**. |

## Verification

- 12/12 new tests pass, and go red on demand: reintroduce the hook imperative → POST_EDIT test fails; grant the teammate `Bash` → tools test fails; nothing else moves.
- Full suite: 144 pass, 9 fail — all 9 pre-existing in `issue-write-gate.bats`, owned by #100, untouched here.
- Codex gate: **REJECT** then **APPROVE**, both posted verbatim on #101 with Lead-generated nonces. The REJECT caught the same class of error as the bug — the imperative patched in `POST_EDIT` but left in `SESSION_START`, and `refactor-repo` still holding the old spawn path.

## Not in scope

- **#109** — `c-bpm-sk-linux-admin` teammates need a shell to do their job, so capability removal is unavailable there; needs a different control.
- #100 (`issue-write-gate.bats` RED), #42 (hook distribution wiring), #102 (gate grammar cannot encode `APPROVE-WITH-CHANGES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)