### PR TITLE
Issues #113 + #112: devils-advocate Judge skill + overnight goal-issue command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,397 +1,215 @@
 # BPMspace Claude Global Skills Library
 
-This repository contains a collection of **skills** and **commands** designed for use with Claude Code CLI, upgraded to **Skills 2.0** with frontmatter-driven configuration. These resources are installed globally on your development machine and reused across multiple projects.
+Skills, agents, commands and hooks for the Claude Code CLI, installed once per
+machine and reused across every project. This README is the operating manual —
+install, run, test. Architecture and the reasoning behind the conventions live
+in [CLAUDE.md](CLAUDE.md).
 
-## Contents
+## 1. What This Is
 
-- `my/` -- all custom `c-bpm-`prefixed items (skills, commands, runbooks), versioned and synced across machines
-- `runbooks/` -- detailed operational guides for recurring processes
-- `templates/` -- issue and pull-request templates
+Every custom item follows the `c-{org}-{type}-{name}` convention — `c-bpm-sk-`
+for skills, `c-bpm-cm-` for commands, `c-bpm-ag-` for agents. The prefix lets
+several organisations' libraries coexist in one `~/.claude/`, and lets an
+upstream item and a customised fork live side by side.
 
-### my/ Directory
+| Path | Holds | Format |
+|------|-------|--------|
+| `my/skills/` | custom skills | directory per skill with `SKILL.md` |
+| `my/commands/` | slash commands | one flat `.md` per command |
+| `my/agents/` | teammate role definitions | one flat `.md` per agent |
+| `my/hooks/` | enforcement hooks (TypeScript source, built to `dist/`) | `.ts` → `.mjs` |
+| `my/shared/` | text blocks stamped into many items | `.md` fragments |
+| `runbooks/`, `templates/` | standard operational guides, issue/PR templates | `.md` |
 
-All custom items follow the `c-bpm-{type}-{name}` naming convention and live under `my/`:
+Items under `my/` are distributed by `c-bpm-cm-library-pull` / `-push`;
+everything else is repo-local reference material.
 
-| Type | Path | Format |
-|------|------|--------|
-| Skills | `my/skills/c-bpm-sk-<name>/` | Directory with `SKILL.md` |
-| Commands | `my/commands/c-bpm-cm-<name>.md` | Flat .md file |
-| Runbooks | `my/runbooks/c-bpm-rb-<name>.md` | Flat .md file |
+## 2. Installation
 
-## Dependency Graph
-
-Relationships between all skills and commands in this library. Arrows show explicit references (one item names another in its content).
-
-```mermaid
-flowchart LR
-    %% --- Node definitions ---
-
-    %% Foundational
-    subgraph foundational["Foundational Patterns"]
-        api-contract([api-contract])
-        bash-secure-script([bash-secure-script])
-        config-secrets([config-secrets])
-        repo-scaffold([repo-scaffold])
-        test-harness([test-harness])
-        curlbash-installer([curlbash-installer])
-        release-ops([release-ops])
-    end
-
-    %% PHP / Web
-    subgraph phpweb["PHP / Web"]
-        flightphp-pro([flightphp-pro])
-        php-crud-api-review([php-crud-api-review])
-    end
-
-    %% Data / Infra
-    subgraph datainfra["Data / Infra"]
-        mariadb-migrations([mariadb-migrations])
-        redis-keyspace([redis-keyspace])
-        n8n-reliability([n8n-reliability])
-    end
-
-    %% Security
-    subgraph security["Security"]
-        appsec-threatlite([appsec-threatlite])
-        tls-http-headers([tls-http-headers])
-    end
-
-    %% Interactive
-    subgraph interactive["Interactive"]
-        grill-me([grill-me])
-        grill-me-issue([grill-me-issue])
-        grill-claude-issue([grill-claude-issue])
-        idea-merge([idea-merge])
-    end
-
-    %% Ops / Team
-    subgraph opsteam["Ops / Team"]
-        auditor([auditor])
-        linux-admin([linux-admin])
-        linux-archive([linux-archive])
-        linux-audit([linux-audit])
-        milestone-type([milestone-type])
-    end
-
-    %% Meta
-    subgraph meta["Meta"]
-        skill-creator([skill-creator])
-        skill-optimizer([skill-optimizer])
-        library-manager([library-manager])
-        llm-selection([llm-selection])
-    end
-
-    %% Commands
-    subgraph commands["Commands"]
-        cm-library-pull{{library-pull}}
-        cm-library-push{{library-push}}
-        cm-library-compare{{library-compare}}
-        cm-openissues-list{{openissues-list}}
-        cm-openissues-team{{openissues-team}}
-        cm-refactor-repo{{refactor-repo}}
-        cm-skill-creator{{skill-creator cmd}}
-        cm-skill-optimizer{{skill-optimizer cmd}}
-    end
-
-    %% --- Skill-to-Skill edges ---
-    appsec-threatlite -->|"references"| tls-http-headers
-    linux-audit -->|"creates findings for"| linux-admin
-    linux-archive -->|"shares host pattern"| linux-audit
-    linux-archive -->|"shares host pattern"| linux-admin
-    skill-creator -->|"delegates to"| skill-optimizer
-    grill-me -->|"hands off to"| grill-me-issue
-    grill-claude-issue -->|"differentiates from"| grill-me
-    grill-claude-issue -->|"differentiates from"| grill-me-issue
-    auditor -->|"loads"| appsec-threatlite
-    auditor -->|"loads"| test-harness
-    library-manager -->|"references"| skill-creator
-    library-manager -->|"references"| skill-optimizer
-    flightphp-pro -->|"references"| milestone-type
-    skill-creator -->|"push workflow"| library-manager
-    skill-optimizer -->|"push workflow"| library-manager
-
-    %% --- Skill-to-Command edges ---
-    library-manager -->|"documents"| cm-library-pull
-    library-manager -->|"documents"| cm-library-push
-    skill-creator -->|"recommends"| cm-library-push
-    skill-optimizer -->|"recommends"| cm-library-push
-
-    %% --- Command-to-Skill edges ---
-    cm-openissues-team -->|"routes tasks to"| appsec-threatlite
-    cm-openissues-team -->|"routes tasks to"| tls-http-headers
-    cm-openissues-team -->|"routes tasks to"| config-secrets
-    cm-openissues-team -->|"routes tasks to"| bash-secure-script
-    cm-openissues-team -->|"routes tasks to"| curlbash-installer
-    cm-openissues-team -->|"routes tasks to"| test-harness
-    cm-openissues-team -->|"routes tasks to"| api-contract
-    cm-openissues-team -->|"routes tasks to"| php-crud-api-review
-    cm-openissues-team -->|"routes tasks to"| flightphp-pro
-    cm-openissues-team -->|"routes tasks to"| redis-keyspace
-    cm-openissues-team -->|"routes tasks to"| mariadb-migrations
-    cm-openissues-team -->|"routes tasks to"| release-ops
-    cm-openissues-team -->|"routes tasks to"| repo-scaffold
-    cm-openissues-team -->|"routes tasks to"| n8n-reliability
-    cm-skill-creator -->|"delegates to"| cm-skill-optimizer
-    cm-skill-creator -->|"recommends"| cm-library-push
-    cm-skill-creator -->|"references"| library-manager
-    cm-skill-optimizer -->|"recommends"| cm-library-push
-    cm-skill-optimizer -->|"references"| library-manager
-
-    %% --- Command-to-Command edges ---
-    cm-library-compare -->|"triggers"| cm-library-pull
-    cm-library-compare -->|"triggers"| cm-library-push
-
-    %% --- Styles ---
-    classDef skillNode fill:#e8f4fd,stroke:#2196F3,color:#1565C0
-    classDef cmdNode fill:#fff9c4,stroke:#f9a825,color:#f57f17
-    classDef foundGroup fill:#e3f2fd,stroke:#1976D2
-    classDef phpGroup fill:#e8f5e9,stroke:#388E3C
-    classDef dataGroup fill:#fff3e0,stroke:#F57C00
-    classDef secGroup fill:#ffebee,stroke:#D32F2F
-    classDef intGroup fill:#f3e5f5,stroke:#7B1FA2
-    classDef opsGroup fill:#e0f2f1,stroke:#00796B
-    classDef metaGroup fill:#f5f5f5,stroke:#616161
-    classDef cmdGroup fill:#fffde7,stroke:#F9A825
-
-    class api-contract,bash-secure-script,config-secrets,repo-scaffold,test-harness,curlbash-installer,release-ops,flightphp-pro,php-crud-api-review,mariadb-migrations,redis-keyspace,n8n-reliability,appsec-threatlite,tls-http-headers,grill-me,grill-me-issue,grill-claude-issue,idea-merge,auditor,linux-admin,linux-archive,linux-audit,milestone-type,skill-creator,skill-optimizer,library-manager,llm-selection skillNode
-    class cm-library-pull,cm-library-push,cm-library-compare,cm-openissues-list,cm-openissues-team,cm-refactor-repo,cm-skill-creator,cm-skill-optimizer cmdNode
-    class foundational foundGroup
-    class phpweb phpGroup
-    class datainfra dataGroup
-    class security secGroup
-    class interactive intGroup
-    class opsteam opsGroup
-    class meta metaGroup
-    class commands cmdGroup
-```
-
-## Item Inventory
-
-### Skills (27)
-
-| Name | Group | Description | User-invocable | Auto-trigger |
-|------|-------|-------------|:--------------:|:------------:|
-| `c-bpm-sk-api-contract` | Foundational | REST API contract, endpoint design, pagination, error handling | No | Yes |
-| `c-bpm-sk-bash-secure-script` | Foundational | Secure Bash script patterns (set -euo pipefail) | Yes | Yes |
-| `c-bpm-sk-config-secrets` | Foundational | .env files, API tokens, credentials, safe config management | No | Yes |
-| `c-bpm-sk-curlbash-installer` | Foundational | curl\|bash install/update/uninstall scripts with YYMMDD versioning | Yes | Yes |
-| `c-bpm-sk-release-ops` | Foundational | CI/CD setup, versioning, deployment, rollback, artefact packaging | No | No |
-| `c-bpm-sk-repo-scaffold` | Foundational | Project structure, directory layout, repository template | No | No |
-| `c-bpm-sk-test-harness` | Foundational | Write tests, test coverage, CI testing (Bash/PHP/API) | Yes | Yes |
-| `c-bpm-sk-flightphp-pro` | PHP/Web | Senior-level Flight PHP v3 patterns, PSR compliance, agent teams | No | Yes |
-| `c-bpm-sk-php-crud-api-review` | PHP/Web | php-crud-api security review and integration guidance | Yes | Yes |
-| `c-bpm-sk-mariadb-migrations` | Data/Infra | Forward-only MariaDB migration pattern, safe schema changes | No | Yes |
-| `c-bpm-sk-redis-keyspace` | Data/Infra | Redis key naming, TTL policies, distributed locks, queues | No | Yes |
-| `c-bpm-sk-n8n-reliability` | Data/Infra | Reliable, maintainable, versionable n8n workflows | No | Yes |
-| `c-bpm-sk-appsec-threatlite` | Security | Threat model, vulnerability check, file handling safety | No | Yes |
-| `c-bpm-sk-tls-http-headers` | Security | TLS configuration, HTTP security headers, reverse proxy setup | No | Yes |
-| `c-bpm-sk-grill-me` | Interactive | Stress-test an idea through relentless questioning | Yes | No |
-| `c-bpm-sk-grill-me-issue` | Interactive | Grill and refine an existing GitHub Issue | Yes | No |
-| `c-bpm-sk-grill-claude-issue` | Interactive | Codex grills Claude on a GitHub Issue (reversed roles) | Yes | No |
-| `c-bpm-sk-idea-merge` | Interactive | Cluster and merge ideas, find duplicates across repos | Yes | No |
-| `c-bpm-sk-auditor` | Ops/Team | Full codebase audit with agent team, produces MD report | Yes | No |
-| `c-bpm-sk-linux-admin` | Ops/Team | Implement fixes for linux-audit findings, agent team | Yes | No |
-| `c-bpm-sk-linux-archive` | Ops/Team | Back up host configs to bpm-{hostname} GitHub repo | Yes | No |
-| `c-bpm-sk-linux-audit` | Ops/Team | Audit Linux host, create GitHub Issues per finding | Yes | No |
-| `c-bpm-sk-milestone-type` | Ops/Team | Enforce milestones and issue type labels on GitHub Issues | Yes | No |
-| `c-bpm-sk-skill-creator` | Meta | Create new skills with Skills 2.0 features, existence checks | No | No |
-| `c-bpm-sk-skill-optimizer` | Meta | Optimize, upgrade, refactor existing skills (Skills 2.0) | No | No |
-| `c-bpm-sk-library-manager` | Meta | Central knowledge hub for c-bpm- convention and sync | No | Yes |
-| `c-bpm-sk-llm-selection` | Meta | Task-to-LLM matching, orchestration protocol, conflict resolution | No | Yes |
-
-### Commands (8)
-
-| Name | Description | Auto-trigger |
-|------|-------------|:------------:|
-| `/c-bpm-cm-library-pull` | Pull c-bpm items from Git repo to local ~/.claude/ | N/A |
-| `/c-bpm-cm-library-push` | Push c-bpm items from local ~/.claude/ to Git repo | N/A |
-| `/c-bpm-cm-library-compare` | Compare local vs repo inventory, optionally repair | N/A |
-| `/c-bpm-cm-openissues-list` | List open GitHub Issues with status, type, milestone table | N/A |
-| `/c-bpm-cm-openissues-team` | Spawn 2-6 Opus teammates to resolve open issues in parallel | N/A |
-| `/c-bpm-cm-refactor-repo` | Spawn agent teammates for parallel refactoring | N/A |
-| `/c-bpm-cm-skill-creator` | Create a new skill with existence checks and Codex review | N/A |
-| `/c-bpm-cm-skill-optimizer` | Optimize/upgrade an existing skill with Codex review | N/A |
-
-## Skill Groups
-
-### Foundational Patterns
-Core conventions and reusable patterns applied across projects. These skills define how scripts, APIs, tests, and installers should be built.
-
-- **api-contract** -- REST endpoint design, pagination, error responses
-- **bash-secure-script** -- `set -euo pipefail`, cleanup traps, idempotent scripts
-- **config-secrets** -- .env management across Bash, PHP, and n8n
-- **curlbash-installer** -- curl|bash distribution pattern with YYMMDD versioning
-- **release-ops** -- Semantic versioning, CI/CD pipelines, rollback procedures
-- **repo-scaffold** -- Consistent directory layout and baseline files for new projects
-- **test-harness** -- bats (Bash), PHPUnit (PHP), curl (API) testing patterns
-
-### PHP / Web
-Flight PHP microframework and API review patterns.
-
-- **flightphp-pro** -- Senior-level Flight PHP v3 patterns with PSR compliance and agent teams
-- **php-crud-api-review** -- Security review for mevdschee/php-crud-api integrations
-
-### Data / Infrastructure
-Database, caching, and workflow automation patterns.
-
-- **mariadb-migrations** -- Forward-only numbered SQL migrations
-- **redis-keyspace** -- Key naming conventions, TTL policies, distributed locks
-- **n8n-reliability** -- Idempotent n8n workflows, error branches, multi-env deployment
-
-### Security
-Application security review and infrastructure hardening.
-
-- **appsec-threatlite** -- Lightweight threat model and vulnerability checklist (references tls-http-headers)
-- **tls-http-headers** -- TLS 1.2+, HSTS, CSP, security headers for Nginx/Apache
-
-### Interactive
-User-facing skills that drive conversations, grilling sessions, and idea management.
-
-- **grill-me** -- Stress-test ideas through relentless questioning (outputs to Obsidian vault)
-- **grill-me-issue** -- Grill and refine an existing GitHub Issue in-place
-- **grill-claude-issue** -- Reversed roles: Codex grills Claude on a GitHub Issue
-- **idea-merge** -- Cluster, deduplicate, and merge ideas across Obsidian vaults and GitHub Issues
-
-### Ops / Team
-Server administration, auditing, and GitHub project management.
-
-- **auditor** -- Full codebase audit with agent team (loads appsec-threatlite + test-harness)
-- **linux-audit** -- Audit Linux host, create GitHub Issues per finding in bpm-{hostname}
-- **linux-admin** -- Implement fixes for linux-audit findings (agent team)
-- **linux-archive** -- Back up host configs to bpm-{hostname} GitHub repo
-- **milestone-type** -- Enforce milestones and issue type labels (bug/enhancement) on all Issues
-
-### Meta
-Skills about skills -- creation, optimization, library management, and model orchestration.
-
-- **skill-creator** -- Create new skills with Skills 2.0 features (delegates to skill-optimizer if exists)
-- **skill-optimizer** -- Optimize, upgrade, and refactor existing skills against Skills 2.0 checklist
-- **library-manager** -- Central knowledge hub for c-bpm- naming convention and push/pull sync
-- **llm-selection** -- Task-to-LLM matching (Claude/Codex/Gemini), orchestration protocol
-
-## Quick Start (neue Maschine)
-
-Komplettes Setup in 3 Schritten:
+### Fresh install
 
 ```bash
-# 1. Repo klonen
 git clone git@github.com:BPMspaceUG/bpm-claude-global-agent-skill-library.git ~/bpm-claude-global-agent-skill-library
-
-# 2. CLI-Tools installieren (bcgasl + c-bpm-cm-library-pull + c-bpm-cm-library-push)
 cd ~/bpm-claude-global-agent-skill-library
-./install --global --with-c-bpm-library
-
-# 3. Alle c-bpm-Items nach ~/.claude/ installieren
-c-bpm-cm-library-pull
+./install --global --with-c-bpm-library   # installs bcgasl + the c-bpm-library CLIs
+c-bpm-cm-library-pull                     # copies all c-bpm items into ~/.claude/
+sudo ./install-hooks --system             # one-time, multi-user: hooks to /usr/local/bin
+./install-hooks                           # per-user: register the hooks in settings.json
 ```
 
-Danach stehen alle Skills, Commands und Runbooks in Claude Code zur Verfügung.
-
-### Ohne Repo-Klon (curl|bash)
-
-Nur `bcgasl` + c-bpm-library-Tools installieren (Repo wird beim ersten `c-bpm-cm-library-pull` automatisch geklont):
+Without a clone, the installer can be piped — the repo is cloned on the first
+`c-bpm-cm-library-pull`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/BPMspaceUG/bpm-claude-global-agent-skill-library/main/install | bash -s -- --global --with-c-bpm-library
-c-bpm-cm-library-pull
 ```
 
-### Nur Standard-Skills (ohne c-bpm-library)
+`bcgasl` installs the standard (non-`c-bpm`) agents, skills, runbooks and
+templates from a **pinned release tarball**, so it does not deliver the latest
+`c-bpm` items — `c-bpm-cm-library-pull` is the path for those.
+
+### Hooks
+
+`install-hooks` installs `dist/*.mjs` and registers them as `PreToolUse` hooks.
+Currently one hook ships: `issue-write-gate`, wired to the `Bash`,
+`mcp__github__issue_write` and `mcp__github__create_issue` matchers — it denies
+any GitHub Issue creation that lacks a milestone or a single `bug`/`enhancement`
+type label.
+
+It registers the hook in **both** standard settings paths
+(`~/.claude/settings.json` and `~/.config/claude/settings.json`)
+**where they exist — a missing settings file is skipped, not created**
+(see #65 / #76). Ensure both files exist before running it if your Claude builds
+read different paths. The script is idempotent; `--dry-run` previews and `--uninstall` reverses
+it.
+
+### Required environment
+
+- `gh` authenticated for the target repositories (`gh auth status`)
+- `codex` CLI on `PATH` — the review authority for every gate
+- `~/.env` (user level, never a project `.env`) with `OPENROUTER_API_KEY` for
+  the substitute-Judge tier
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` for the agent-team commands
+- `bats` for the test suite, `node` for the hooks
+
+### Verification
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/BPMspaceUG/bpm-claude-global-agent-skill-library/main/sync | bash
+ls ~/.claude/skills | grep -c '^c-bpm-sk-'            # 1. skills landed
+command -v bcgasl c-bpm-cm-library-pull               # 2. CLIs on PATH
+# 3. hook registered in every settings file that exists
+for f in ~/.claude/settings.json ~/.config/claude/settings.json; do \
+  [ -f "$f" ] && { grep -q issue-write-gate "$f" && echo "OK $f" || echo "GAP $f"; }; done
+echo '{"tool_name":"Bash","tool_input":{"command":"gh issue create --title p --body p"},"cwd":"'"$PWD"'"}' \
+  | node ~/.claude/hooks/dist/issue-write-gate.mjs    # 4. must print "deny"
+gh auth status && codex --version                      # 5. review authority reachable
 ```
 
-With n8n skills:
-```bash
-curl -fsSL https://raw.githubusercontent.com/BPMspaceUG/bpm-claude-global-agent-skill-library/main/sync | bash -s -- --n8n
-```
+Step 3 must report the hook in **every settings file that exists**. If only one
+of the two exists, that is the #65 / #76 gap — fix it before relying on the
+gate, do not read it as a successful install.
 
-## Updates
+### Updating an existing installation
 
-### Repo bereits geklont
+After changes land on `main`, every machine needs all three steps — pulling the
+repo alone leaves the installed copies under `~/.claude/` stale, which is how
+superseded content keeps executing (see #114):
 
 ```bash
 cd ~/bpm-claude-global-agent-skill-library && git pull
-c-bpm-cm-library-pull              # Aktualisiert alle c-bpm-Items lokal
+c-bpm-cm-library-pull    # refresh the installed copies in ~/.claude/
+./install-hooks          # idempotent re-registration of the current hooks
 ```
 
-### Oder via bcgasl
+Then re-run the verification block above. The same "only existing settings
+files are updated" caveat (#65 / #76) applies to the re-registration.
+
+## 3. How the Agent Teams Work
+
+The team commands implement segregation of duty as a capability, not a
+guideline. The Team Lead coordinates, reviews and approves but writes no code;
+teammates implement and report; the Lead never approves alone.
+
+**Codex is the review authority.** Three gates are Codex-gated —
+plan approval, test-design approval, and test verification — each invoked
+through `c-bpm-sk-devils-advocate`, which fetches the live Issue, sanitises the
+payload, and falls back down a substitute-Judge ladder when Codex is
+unreachable. A gate never passes on a missing review.
+
+**Milestones are the state machine.** Every issue moves
+`new` → `planned` → `plan-approved` → `test-designed` →
+`test-design-approved` → `implemented` → `tested-success` / `tested-failed` →
+`test-approved`, updated at each transition. `DONE` is **human-only** — agents
+never set it. Every issue also carries exactly one type label, `bug` or
+`enhancement`; `issue-write-gate` enforces both mechanically.
+
+**Communication is Issues-only.** The plan, rejected plans, progress and every
+decision go in the Issue body or comments — never into side-car `.md` files.
+Codex is handed an Issue reference, not a pasted document.
+
+**Teammate lifecycle** is currently written policy, not yet encoded in the
+commands: finished teammates should be shut down rather than left idle, and
+fresh spawns are preferred over reusing a context-rotted teammate. Tracked in
+#120.
+
+Entry points:
+
+- `/c-bpm-cm-openissues-team` — interactive run over the open issues, user sees
+  the plan before the team spawns.
+- `/c-bpm-cm-goal-issue` — unattended run (typically overnight); never waits for
+  user confirmation, loops Codex-gated batches until every in-scope issue meets
+  its definition of done.
+
+## 4. Model Policy
+
+`c-bpm-sk-llm-selection` is the **single source of truth** for model selection
+and orchestration. No skill, command or script may hard-wire a model name or
+version — not for Codex (`codex exec` runs bare, with no `-m`), not for
+Claude, not for the OpenRouter fallback tier. This README therefore names zero
+model versions, and `tests/bash/c-bpm-sk-codex-flag.bats` fails the build if a
+pin reappears (see #98).
+
+## 5. Testing
 
 ```bash
-bcgasl                           # Standard-Items aktualisieren
-bcgasl --n8n                     # Mit n8n-Skills
-bcgasl --dry-run                 # Vorschau ohne Änderungen
+./tests/run_tests.sh     # requires bats on PATH; equivalent to: bats tests/bash/
+bats tests/bash/readme-guards.bats   # a single suite
 ```
 
-## c-bpm-library: Push/Pull Sync
+The suite is offline and deterministic. It covers the installer and sync scripts
+(`install.bats`, `sync-dedup.bats`, `bpm-bootstrap.bats`,
+`c-bpm-cm-library-compare.bats`), the enforcement hook
+(`c-bpm-sk-issue-write-gate.bats`), and drift guards over the skills and
+commands themselves — model-version pins, Codex invocation hygiene, the review
+loop, the Issues-only communication block, the goal-issue command, and this
+README.
 
-Synchronise custom `c-bpm-` items between machines via this Git repository.
+**Known red:** 9 of the 29 `c-bpm-sk-issue-write-gate.bats` fixtures fail
+because the runner never exports `FIXTURE_REPO` — a test-harness defect, not a
+hook defect, tracked in #100. A clean checkout is expected to show exactly those
+failures and no others. End-to-end execution of skills (as opposed to static
+guards) is not covered yet; that harness is #122.
 
-### Pull (repo -> local)
+## 6. Key Commands
 
-```bash
-c-bpm-cm-library-pull                  # Pull all c-bpm-items
-c-bpm-cm-library-pull --dry-run        # Preview what would change
-c-bpm-cm-library-pull --force          # Overwrite conflicts (repo wins)
-c-bpm-cm-library-pull --only-skills    # Pull only skills
-c-bpm-cm-library-pull --only-commands  # Pull only commands
-c-bpm-cm-library-pull --only-runbooks  # Pull only runbooks
-c-bpm-cm-library-pull --verbose        # Detailed output
-```
+Slash commands, invocable in any Claude Code session once installed:
 
-### Push (local -> repo)
+| Command | Purpose |
+|---------|---------|
+| `/c-bpm-cm-openissues-list` | Open-issues dashboard with status, type and milestone; creates missing milestones |
+| `/c-bpm-cm-openissues-team` | Spawn a teammate team to work the open issues in parallel; Codex-reviewed, tests mandatory |
+| `/c-bpm-cm-goal-issue` | Unattended goal run; loops Codex-gated teams per batch until every in-scope issue is done |
+| `/c-bpm-cm-refactor-repo` | Spawn a teammate team for parallel refactoring; Codex-reviewed, milestone-tracked |
+| `/c-bpm-cm-library-pull` | Sync c-bpm items from this repo into `~/.claude/` |
+| `/c-bpm-cm-library-push` | Sync c-bpm items from `~/.claude/` into this repo; auto-commits and pushes |
+| `/c-bpm-cm-library-compare` | Show which c-bpm items differ between `~/.claude/` and the repo; optionally repair |
+| `/c-bpm-cm-skill-creator` | Create a skill; detects an existing `c-bpm-sk-` version and delegates to the optimizer |
+| `/c-bpm-cm-skill-optimizer` | Fork, customise or upgrade an existing skill under Codex-reviewed quality gates |
 
-```bash
-c-bpm-cm-library-push                          # Push all c-bpm-items
-c-bpm-cm-library-push --dry-run                # Preview what would change
-c-bpm-cm-library-push --force                  # Overwrite conflicts (local wins)
-c-bpm-cm-library-push --message "custom msg"   # Custom commit message
-c-bpm-cm-library-push --only-skills            # Push only skills
-c-bpm-cm-library-push --verbose                # Detailed output
-```
+Shell CLIs installed by `./install`: `bcgasl` (standard items from the pinned
+release) and `c-bpm-cm-library-pull` / `-push` / `-compare` — the sync engines
+behind the slash commands above. `./install-hooks` stays in the repo. Common
+sync flags: `--dry-run`, `--verbose`, `--force`, `--clean`, `--only-skills`,
+`--only-agents`, `--only-commands`; push adds `--message`, compare `--repair`.
 
-### Conflict Detection
+### Sync conflict handling
 
-Both scripts track a SHA256 baseline per item in `~/.claude/.c-bpm-library-sync`. When an item has changed on **both** sides (locally and in the repo) since the last sync, it is flagged as a conflict and **skipped**:
-
-```
-  X skills/c-bpm-sk-foo (CONFLICT: changed locally AND in repo)
-
-CONFLICTS: 1 item(s) changed on both sides.
-  Review manually, then re-run. Or use --force to let repo win.
-```
+Both sync scripts track a SHA256 baseline per item in
+`~/.claude/.c-bpm-library-sync`. An item changed on **both** sides since the
+last sync is flagged and skipped rather than silently overwritten.
 
 | Scenario | Pull | Push |
 |----------|------|------|
-| Only repo changed | Updates local | -- |
-| Only local changed | -- | Updates repo |
+| Only repo changed | Updates local | — |
+| Only local changed | — | Updates repo |
 | Both changed | **CONFLICT** (skipped) | **CONFLICT** (skipped) |
 | Both changed + `--force` | Repo wins | Local wins |
 | No baseline (first sync) | Updates local | Updates repo |
 
-### Typischer Workflow
-
-```bash
-# Auf Maschine A: neues Item erstellen und pushen
-# (z.B. neuen Skill in ~/.claude/skills/c-bpm-sk-foo/ anlegen)
-c-bpm-cm-library-push
-
-# Auf Maschine B: Items synchronisieren
-c-bpm-cm-library-pull
-```
-
-## Usage in Prompts
-
-Reference these definitions in your prompts to Claude Code CLI:
-
-- *"Use the Bash secure script standard to implement the installer."*
-- *"Run a security review using the appsec-threatlite checklist."*
-
 ## External Skill Packs
 
-The n8n skill pack is maintained in a <a href="https://github.com/czlonkowski/n8n-skills" target="_blank">separate repository</a>. Use `bcgasl --n8n` to install it.
+The n8n skill pack is maintained in a <a href="https://github.com/czlonkowski/n8n-skills" target="_blank">separate repository</a>. Install it with `bcgasl --n8n`.
 
 ## License
 
-This library is provided under the MIT License. See the `LICENSE` file for details.
+MIT. See the `LICENSE` file.

--- a/my/commands/c-bpm-cm-goal-issue.md
+++ b/my/commands/c-bpm-cm-goal-issue.md
@@ -1,0 +1,135 @@
+---
+name: c-bpm-cm-goal-issue
+description: "Overnight goal run — unattended issue processing, nachtlauf, run all open issues while the user is offline, autonomous goal issue execution. Loops Codex-gated teams per batch until every in-scope issue meets its DoD."
+allowed-tools: Bash, Read, Write, Edit, MultiEdit, Glob, Grep, LS, Task, Teammate, SendMessage
+---
+
+# /c-bpm-cm-goal-issue — Overnight Goal Run
+
+You are the GOAL LEAD. You run unattended, typically overnight.
+
+Model selection for yourself and for every teammate is owned solely by
+`c-bpm-sk-llm-selection`. This command never names a model or a version.
+
+$ARGUMENTS
+
+---
+
+## AUTONOMY CONTRACT (overrides every invoked command)
+
+- The user is offline. The GOAL LEAD **never asks the user** anything — no
+  questions, no confirmations, no approval requests, no escalations.
+- The GOAL LEAD **never waits for user confirmation** at any gate, including the
+  Phase 2c confirmation step of `/c-bpm-cm-openissues-team`, which is overridden
+  for the whole duration of this run.
+- Codex is the counterpart, not the user: every review gate goes to Codex, and
+  Codex output is run and tested, never trusted on sight.
+- Unresolvable question or ambiguity → take the most pragmatic assumption, post
+  it as an issue comment prefixed `ASSUMPTION:`, and continue.
+- Never block, never abort the run. A stuck issue becomes `documented-blocked`,
+  not a stopped run.
+- Delegation and segregation of duty stay intact: teammates implement, Codex
+  reviews, the GOAL LEAD coordinates. `DONE` is human-only and no agent ever
+  sets it.
+
+---
+
+## G0 — SCOPE & CONTEXT REBUILD (from scratch, no cached context)
+
+1. `git pull --rebase`; on conflict, stop the batch, comment the conflict on the
+   affected issues, continue with the next batch.
+2. Owner and repo come from `git remote -v` — never guessed.
+3. Resolve scope from `$ARGUMENTS`:
+   - explicit issue numbers (`112 113 117`)
+   - `label:<name>`
+   - any other filter expression passed through to `gh`
+   - **Default scope (no arguments): every open issue in milestone `new`.**
+4. Rebuild context from scratch — no memory of previous runs is assumed:
+   `CLAUDE.md`, the repo's main log/README, and for every in-scope issue its
+   body **and** all comments via `gh api .../issues/<n>` and
+   `gh api .../issues/<n>/comments`.
+5. External documentation is fetched only when a concrete gap blocks work.
+
+---
+
+## G1 — PLANNING: DEPENDENCY GRAPH → BATCHES
+
+1. Build a dependency graph from issue cross-references and expected file
+   overlap. Two issues touching the same file are dependent.
+2. Topologically sort the graph into batches of 2–6 issues with no file overlap
+   inside a batch.
+3. Per-issue skill selection follows the Phase 3 skill table of
+   `/c-bpm-cm-openissues-team` — referenced, never duplicated here.
+4. Post the batch plan as a comment on every in-scope issue before execution.
+
+---
+
+## G2 — BATCH EXECUTION
+
+For each batch, in topological order:
+
+- Invoke `/c-bpm-cm-openissues-team` with the batch's issue numbers.
+- That command owns the full milestone lifecycle and its three Codex gates
+  (plan, test design, implementation). They are inherited, not re-implemented.
+- The autonomy contract above overrides its user-confirmation points.
+- Teammates never commit. Commits happen centrally in G3.
+
+---
+
+## G3 — PER-ISSUE COMMIT (direct to main)
+
+Policy conflict PC-2, ratified: the Issue #112 spec wins for THIS command.
+
+- The GOAL LEAD commits, teammates never do.
+- An issue is committed only once it reaches the `test-approved` milestone.
+- **One commit per issue**, message `Issue #<N>: <summary>`, pushed directly to
+  `main` — no PRs, no feature branches, no batching of unrelated issues.
+- `git commit` + `git push` run after the issue's own tests are green.
+- `DONE` is human-only: the GOAL LEAD never sets it, not even after pushing.
+
+---
+
+## G4 — GOAL LOOP
+
+1. After each batch, re-fetch the scope — issues created or re-opened during the
+   run join the next batch.
+2. **Exit condition: the loop exits once every in-scope issue either meets its DoD or is `documented-blocked`.**
+3. Stall guard: two consecutive batches with zero progress on an issue → post an `ASSUMPTION:` / blocker comment, mark that issue `documented-blocked`, and stop working it. This guarantees the loop terminates.
+
+**Definition of Done (DoD), per issue:** tests green and milestone
+`test-approved`; all Codex findings addressed or answered in the issue; the
+commit pushed to `main`; every assumption documented as an issue comment.
+
+---
+
+## G5 — FINAL REVIEW & MORNING REPORT
+
+1. Final devil's-advocate pass over the whole run via `c-bpm-sk-devils-advocate`
+   (that skill owns its own review ladder). Findings become new issues.
+2. Write the morning report to `SUMMARY-<YYYYMMDD>-<HHMM>.md` in the repo root
+   and leave it untracked.
+
+   **Precedence for this single artifact:** the Issue #112 spec (an explicit
+   user directive) **takes precedence** over the generic no-side-car rule below.
+   The GitHub Issues remain the **authoritative** record: every per-issue fact —
+   plan, assumption, review verdict, blocker — is posted as an **issue comment**
+   FIRST, and the SUMMARY is only a user-mandated aggregation of what is already
+   in the issues, never an agent-invented plan file. The ban in the block below
+   targets agent-invented side-car docs; it is not waived for anything else.
+
+3. Report contents: per issue → final milestone, commit SHA, DoD status,
+   assumptions, blockers; plus the devil's-advocate findings and the new issues
+   filed from them.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-api-contract/SKILL.md
+++ b/my/skills/c-bpm-sk-api-contract/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-api-contract
 description: "API design rules — REST API contract, endpoint design, pagination, error handling, API review. Predictable endpoints, filtering, and consistent error responses."
 enforcement: block

--- a/my/skills/c-bpm-sk-appsec-threatlite/SKILL.md
+++ b/my/skills/c-bpm-sk-appsec-threatlite/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-appsec-threatlite
 description: "Security review checklist — threat model, appsec review, vulnerability check, file handling safety, auth review, compliance, remediation tracking. Lightweight security review with structured reporting."
 enforcement: block

--- a/my/skills/c-bpm-sk-auditor/SKILL.md
+++ b/my/skills/c-bpm-sk-auditor/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-auditor
 description: "Audit this repo — full codebase review, code quality check, security audit, due diligence, maintenance handover, review this codebase. Produces [REPONAME]-YYMMDD-HHSS.md report. No issues created."
 user-invocable: true
@@ -155,7 +154,7 @@ Write `[REPONAME]-YYMMDD-HHSS.md`, send shutdown_request to all teammates, TeamD
 ## References
 
 - `references/report-template.md` — Full report Markdown template
-- `references/codex-prompts.md` — Per-phase Codex devil's advocate prompts
+- `references/codex-prompts.md` — Per-phase devil's advocate review prompts (run via `c-bpm-sk-devils-advocate`)
 
 ## Constraints
 
@@ -166,7 +165,7 @@ Write `[REPONAME]-YYMMDD-HHSS.md`, send shutdown_request to all teammates, TeamD
 - Use newest Opus (see `c-bpm-sk-llm-selection`) for all teammates (inherit, never haiku)
 - Include severity ratings for all findings
 - Run existing tests if safe to do so
-- Invoke Codex ONLY via: `codex exec --skip-git-repo-check [PROMPT]` (if unavailable, use fallback chain)
+- Run the review via `c-bpm-sk-devils-advocate` (Codex primary; OpenRouter fallback per `c-bpm-sk-llm-selection`) — never a review CLI directly
 
 ### MUST NOT
 - Create GitHub issues (report only)

--- a/my/skills/c-bpm-sk-auditor/references/codex-prompts.md
+++ b/my/skills/c-bpm-sk-auditor/references/codex-prompts.md
@@ -1,37 +1,35 @@
-# Codex Devil's Advocate Prompts
+# Devil's Advocate Prompts
 
-Codex MUST be invoked ONLY via shell: `codex exec --skip-git-repo-check [PROMPT]`
+Every review below is run through `c-bpm-sk-devils-advocate` (Codex primary;
+OpenRouter fallback per `c-bpm-sk-llm-selection`). That skill owns the live-Issue
+fetch, the canonical sanitized invocation, and the substitute-Judge ladder — this
+file supplies only what the Judge must challenge.
 
 ## Per-Phase Reviews
 
 ### After Phase 1 (Codebase Understanding)
 
-```bash
-codex exec --skip-git-repo-check "Devil's advocate review of codebase analysis for [REPONAME]. Challenge: 1) Is the tech stack detection complete? Any frameworks/tools missed? 2) Is the architecture description accurate or oversimplified? 3) Are there hidden entry points or config files not found? 4) Any dependency risks not flagged? Findings: [PHASE 1 SUMMARY]"
-```
+Devil's advocate review of codebase analysis for [REPONAME]. Challenge: 1) Is the tech stack detection complete? Any frameworks/tools missed? 2) Is the architecture description accurate or oversimplified? 3) Are there hidden entry points or config files not found? 4) Any dependency risks not flagged? Findings: [PHASE 1 SUMMARY]
 
 ### After Phase 2 (Pattern Checks)
 
-```bash
-codex exec --skip-git-repo-check "Devil's advocate review of pattern analysis for [REPONAME] ([TECH STACK]). Challenge: 1) False positives - issues flagged that aren't real problems in this stack 2) Missed anti-patterns common in [FRAMEWORK] projects 3) Are security findings real vulnerabilities or theoretical? 4) Performance concerns - are they measurable or speculative? 5) Migration safety - any destructive patterns missed? Findings: [PHASE 2 SUMMARY]"
-```
+Devil's advocate review of pattern analysis for [REPONAME] ([TECH STACK]). Challenge: 1) False positives - issues flagged that aren't real problems in this stack 2) Missed anti-patterns common in [FRAMEWORK] projects 3) Are security findings real vulnerabilities or theoretical? 4) Performance concerns - are they measurable or speculative? 5) Migration safety - any destructive patterns missed? Findings: [PHASE 2 SUMMARY]
 
 ### After Phase 3 (Test Plan)
 
-```bash
-codex exec --skip-git-repo-check "Devil's advocate review of test plan for [REPONAME]. Challenge: 1) Are coverage gaps real or already tested indirectly? 2) Are recommended tests practical and valuable? 3) Any critical paths missed entirely? 4) Is the test execution plan safe (no side effects)? Test plan: [PHASE 3 SUMMARY]"
-```
+Devil's advocate review of test plan for [REPONAME]. Challenge: 1) Are coverage gaps real or already tested indirectly? 2) Are recommended tests practical and valuable? 3) Any critical paths missed entirely? 4) Is the test execution plan safe (no side effects)? Test plan: [PHASE 3 SUMMARY]
 
 ### Final Review (Complete Report)
 
-```bash
-codex exec --skip-git-repo-check "Final devil's advocate review of complete audit report for [REPONAME]. Challenge every finding. Are there false positives? Missed issues? Is severity accurate? Are recommendations actionable? Full report: [REPORT CONTENT]"
-```
+Final devil's advocate review of complete audit report for [REPONAME]. Challenge every finding. Are there false positives? Missed issues? Is severity accurate? Are recommendations actionable? Full report: [REPORT CONTENT]
 
 ## Rules
 
-- Run Codex after EACH phase completes, not just at the end
-- Include Codex disagreements in the report (Section 8)
-- If Codex identifies missed issues, add them to relevant sections
-- If Codex disputes severity, note both assessments
-- If Codex is unavailable, try fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable, note "Independent review skipped — no reviewer available" in report. Always log which reviewer was used.
+- Run the review after EACH phase completes, not just at the end
+- Include Judge disagreements in the report (Section 8)
+- If the Judge identifies missed issues, add them to relevant sections
+- If the Judge disputes severity, note both assessments
+- If the Judge is unreachable, `c-bpm-sk-devils-advocate` descends the
+  substitute-Judge ladder defined in `c-bpm-sk-llm-selection`. If every tier is
+  unreachable, note "Independent review skipped — no reviewer available" in the
+  report. Always log which Judge produced each verdict.

--- a/my/skills/c-bpm-sk-bash-secure-script/SKILL.md
+++ b/my/skills/c-bpm-sk-bash-secure-script/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-bash-secure-script
 description: "Secure Bash script — write bash script, shell script, automation script, bash best practices, set -euo pipefail. Robust, maintainable, and secure Bash patterns."
 enforcement: block

--- a/my/skills/c-bpm-sk-bootstrap-ui/SKILL.md
+++ b/my/skills/c-bpm-sk-bootstrap-ui/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-bootstrap-ui
 description: Guidance for building UIs with Bootstrap focusing on consistent styling, responsiveness, and accessibility. Use when creating modals, forms, alerts, and responsive layouts with Bootstrap. Derived from S09c.
 ---

--- a/my/skills/c-bpm-sk-config-secrets/SKILL.md
+++ b/my/skills/c-bpm-sk-config-secrets/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-config-secrets
 description: "Secrets management — .env files, API tokens, credentials, config management, secret handling. Safe configuration across Bash, PHP, and n8n."
 enforcement: block

--- a/my/skills/c-bpm-sk-curlbash-installer/SKILL.md
+++ b/my/skills/c-bpm-sk-curlbash-installer/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-curlbash-installer
 description: "curl|bash installer — create installer, install script, update script, uninstall script, YYMMDD versioning. Distribution pattern for CLI tools."
 enforcement: block

--- a/my/skills/c-bpm-sk-datatables/SKILL.md
+++ b/my/skills/c-bpm-sk-datatables/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-datatables
 description: Standardised DataTables.net usage for tabular data with server-side processing, accessibility, and performance. Use when building front-end pages with tabular data or integrating server-side DataTables. Derived from S09a.
 ---

--- a/my/skills/c-bpm-sk-devils-advocate/SKILL.md
+++ b/my/skills/c-bpm-sk-devils-advocate/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: c-bpm-sk-devils-advocate
+description: "Invoke the independent Judge — codex review, independent review, devil's advocate review, review gate, judge this issue, get a verdict, second pair of eyes. Canonical Judge invocation: live Issue fetch, sanitized sandboxed call, substitute-Judge ladder."
+enforcement: block
+intentPatterns: "codex review;;independent review;;devil'?s advocate review;;review gate;;judge (this )?issue"
+user-invocable: true
+argument-hint: "[issue number]"
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Devil's Advocate — Canonical Judge Invocation
+
+This skill is the **only** place in the library that invokes the Judge. Every review
+gate — plan approval, test design, implementation, audit, release — calls this skill
+instead of running a review CLI itself. Model and ladder policy live in
+`c-bpm-sk-llm-selection`; this skill is the operational half.
+
+It fills the **Judge seat** of the Producer ↔ Judge review loop defined in
+`c-bpm-sk-llm-selection` (loop mechanics, no cycle cap, guard rails — all defined
+there, not restated here). The Producer never judges its own artifact.
+
+## Live Issue Fetch (mandatory, first step)
+
+**Fetch the live Issue body and comments via gh api BEFORE invoking the Judge.**
+The payload is Issue-sourced: never an authored `.md`, never a side-car plan file,
+never a summary retyped from memory.
+
+```bash
+OWNER=…; REPO=…; N=…          # discover OWNER/REPO from `git remote -v`
+{ gh api repos/${OWNER}/${REPO}/issues/${N} --jq .body
+  gh api repos/${OWNER}/${REPO}/issues/${N}/comments --jq '.[].body'
+} > "${payload:=$(mktemp)}"
+```
+
+- Read the thread **at invocation time**. A thread that moved on since the last read
+  invalidates the verdict; quote the timestamp of the newest comment you read.
+- `gh issue view --comments` is unreliable (deprecated GraphQL path, can return
+  empty) — use the two `gh api` calls above.
+- **Judge unable.** If the fetch fails (auth, network, deleted Issue), the Judge is
+  unable to review: descend the ladder below, and if no Judge can be reached, report
+  **documented-blocked** on the Issue. Never emit a fabricated verdict, never guess
+  what the Judge would have said, never let a gate pass on a missing review.
+
+## Primary Judge — Codex
+
+Codex is the primary Judge. Canonical invocation (from `c-bpm-sk-llm-selection`,
+verbatim — sanitized non-login shell, network-enabled workspace sandbox, payload on
+stdin):
+
+```bash
+env -u BASH_ENV -u ENV bash --noprofile --norc -c \
+  'codex exec --skip-git-repo-check -s workspace-write -c sandbox_workspace_write.network_access=true 2>&1' \
+  < "${payload}"
+```
+
+- The sanitizing tokens (`env -u BASH_ENV -u ENV`, `--noprofile`, `--norc`) and the
+  token order are load-bearing — see issue #94 and #117 in `c-bpm-sk-llm-selection`.
+- `-s workspace-write` with `sandbox_workspace_write.network_access=true` lets the
+  Judge actually read the workspace and reach the network (issue #117).
+  `danger-full-access` is never sanctioned — workspace-write is the ceiling.
+- Ask for an explicit verdict: `APPROVE` or `REJECT` with specific, actionable
+  reasons. A verdict without reasons is not a verdict — re-ask.
+
+### Auth failure recovery (exactly once)
+
+Auth-shaped failures only — `refresh_token_reused`, `token_expired`,
+`401 Unauthorized`, "log out and sign in again":
+
+```bash
+cac pull --tool codex     # restores ~/.codex/auth.json
+```
+
+Then retry the invocation **once**. If the pull fails or the single retry still
+returns 401, stop retrying (an older bundle can overwrite a good token) and descend
+the ladder. Do not run this for transport, prompt, or sandbox failures.
+
+## Substitute-Judge ladder
+
+Ladder and family policy are defined in `c-bpm-sk-llm-selection`:
+Codex → OpenRouter cheap frontier → Gemini → next available independent model.
+
+- A substitute is a **substitute, not a co-Judge** — exactly one active Judge at a
+  time, never a tiebreaker.
+- **OpenRouter** is the first substitute tier. Use the OpenRouter MCP server if it
+  is registered in the session; otherwise `curl` the API directly. Take
+  `OPENROUTER_API_KEY` from the user-level `~/.env` — never a project-level `.env`.
+  Resolve the newest slug of a sanctioned family from the live catalog
+  (`/api/v1/models`) at invocation time; this skill names no model versions.
+- The Issue payload is embedded in the request body for non-CLI Judges — same
+  content, same live fetch.
+- Record which Judge produced the verdict in the Issue comment. If every tier is
+  unreachable: **documented-blocked**, gate does not pass.
+
+## Rules
+
+- MUST fetch the Issue live before every invocation — including re-reviews after a
+  Producer revision.
+- MUST post the verdict verbatim as an Issue comment, naming the Judge used.
+- MUST NOT be invoked by the Producer to judge its own artifact.
+- MUST NOT be wrapped in a login/rc shell (`bash -l`, `bash -lc`).
+- MUST NOT pin a model version anywhere — `c-bpm-sk-llm-selection` resolves models.
+
+<!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
+## Communication: GitHub Issues only
+
+All work for this item is documented in its GitHub Issue — never in side-car files.
+
+- **The Issue is the single source of truth.** The task, the plan, why a plan was rejected, the revised plan, progress, and every decision go in the Issue body or comments — posted as they happen.
+- **No side-car MD files, ever.** Never write `~/.claude/plans/*.md`, scratchpad `prompt.md` / plan `.md`, `ISSUE_<n>_PLAN.md`, or any doc that duplicates what belongs in the Issue. Plan/review artifacts the harness writes (e.g. ExitPlanMode into `~/.claude/plans/*.md`) are **transient and non-authoritative** — mirror them into the Issue immediately and treat the Issue as the record.
+- **Codex is invoked by Issue reference, not by pasting a plan into a file.** Fetch the Issue **body and its comments** live and pipe them to a sanitized `codex exec` — e.g. `gh api repos/<owner>/<repo>/issues/<n> --jq .body` **and** `gh api repos/<owner>/<repo>/issues/<n>/comments`, piped in together. (`gh issue view --comments` is unreliable — it hits deprecated GraphQL and can return empty.) The stdin is Issue-sourced, never an authored `.md`.
+- **Precedence:** this rule OVERRIDES any local "write a plan doc" / "save to a file" wording anywhere in this item. The only allowed non-Issue output is the terminal summary shown to the user; the durable record still lives in the Issue.
+
+Canonical source: `my/shared/issue-communication-protocol.md`. Governance: `c-bpm-sk-milestone-type` (documentation rule) + `c-bpm-sk-llm-selection` (Codex-by-Issue).
+<!-- END issue-comms -->

--- a/my/skills/c-bpm-sk-flightphp-pro/SKILL.md
+++ b/my/skills/c-bpm-sk-flightphp-pro/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-flightphp-pro
 description: "Flight PHP expert — Flight framework, PHP routing, middleware, DI container, Flight API, PHP 8.3. Senior-level Flight PHP v3 patterns with PSR compliance and agent team orchestration."
 enforcement: block

--- a/my/skills/c-bpm-sk-flightphp-pro/references/team-orchestration.md
+++ b/my/skills/c-bpm-sk-flightphp-pro/references/team-orchestration.md
@@ -212,10 +212,12 @@ The teammate posts a plan as a comment on their assigned issue(s). The plan must
 ### Dual Review
 
 1. **Team Lead reviews** — Checks scope adherence, architectural fit, completeness
-2. **Codex reviews** — Run:
-   ```bash
-   codex exec --skip-git-repo-check "Review this plan for issue #N in a Flight PHP project. Check for: scope creep, missing test coverage, architectural violations, security concerns. Plan: <plan content>"
-   ```
+2. **The Judge reviews** — run the review via `c-bpm-sk-devils-advocate` (Codex
+   primary; OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
+
+   > Review this plan for issue #N in a Flight PHP project. Check for: scope creep,
+   > missing test coverage, architectural violations, security concerns.
+   > Plan: `<plan content>`
 
 ### Approval Criteria
 
@@ -269,10 +271,12 @@ final class UserControllerTest extends TestCase
 ### Dual Review
 
 1. **Team Lead reviews** — Checks coverage completeness, edge cases, isolation
-2. **Codex reviews** — Run:
-   ```bash
-   codex exec --skip-git-repo-check "Review this PHPUnit test design for a Flight PHP project. Check for: adequate coverage, proper Engine isolation, missing edge cases, assertion quality. Test design: <test design content>"
-   ```
+2. **The Judge reviews** — run the review via `c-bpm-sk-devils-advocate` (Codex
+   primary; OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
+
+   > Review this PHPUnit test design for a Flight PHP project. Check for: adequate
+   > coverage, proper Engine isolation, missing edge cases, assertion quality.
+   > Test design: `<test design content>`
 
 ### Approval
 
@@ -331,10 +335,12 @@ If tests fail:
 Team Lead and Codex independently verify:
 
 1. **Team Lead** — Pulls the branch, runs tests, reviews code
-2. **Codex** — Run:
-   ```bash
-   codex exec --skip-git-repo-check "Review this implementation for a Flight PHP project. Check: tests pass, code follows Flight conventions, no security issues, no breaking changes. Code diff: <diff content>"
-   ```
+2. **The Judge** — run the review via `c-bpm-sk-devils-advocate` (Codex primary;
+   OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
+
+   > Review this implementation for a Flight PHP project. Check: tests pass, code
+   > follows Flight conventions, no security issues, no breaking changes.
+   > Code diff: `<diff content>`
 
 Both must approve. Move to milestone: `test-approved`.
 
@@ -380,13 +386,12 @@ Independent review is mandatory for all Claude-generated code (Codex primary, Ge
 
 ### Invocation
 
-Codex is invoked ONLY via:
+The Judge is invoked ONLY through `c-bpm-sk-devils-advocate` (Codex primary;
+OpenRouter fallback per `c-bpm-sk-llm-selection`). That skill owns the live-Issue
+fetch, the canonical sanitized command, and the substitute-Judge ladder.
 
-```bash
-codex exec --skip-git-repo-check "<review prompt>"
-```
-
-Never use interactive mode. Never skip independent review at mandatory gates (use fallback chain if Codex unavailable).
+Never use interactive mode. Never skip independent review at mandatory gates (the
+skill descends the ladder if Codex is unreachable).
 
 ### Mandatory Review Gates
 
@@ -396,15 +401,16 @@ Independent review (Codex → Gemini → other) is required at exactly 3 gates:
 2. **Test design approval** (Phase 5) — Reviews the test design
 3. **Test verification** (Phase 7) — Reviews the implementation and test results
 
-### If Codex Is Unavailable
+### If the Judge Is Unavailable
 
-Try the fallback chain before stopping:
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder defined in
+`c-bpm-sk-llm-selection`:
 
-1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
-2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
-3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
+1. **Primary:** Codex
+2. **Fallback 1:** OpenRouter cheap frontier
+3. **Fallback 2:** Gemini, then the next available independent model
 
-If ALL models in the chain are unavailable:
+If ALL tiers in the ladder are unreachable:
 - **Notify the user** immediately
 - **Do NOT proceed** without at least one independent review
 - Log which reviewer was used (Codex/Gemini/other) in all review comments

--- a/my/skills/c-bpm-sk-grill-claude-issue/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-claude-issue/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-grill-claude-issue
 description: "Codex grills Claude on an issue — grill claude, review claude's work, independent review, codex review issue. Reversed roles: Codex asks questions, Claude researches and answers."
 enforcement: block
@@ -95,10 +94,8 @@ Budgets:
 
 ### Per-Round Protocol
 
-1. **Claude calls Codex** with the structured prompt:
-   ```bash
-   codex exec --skip-git-repo-check "<structured prompt with all input fields>"
-   ```
+1. **Claude calls the Judge** through `c-bpm-sk-devils-advocate`, passing the
+   structured prompt with all input fields
 2. **Codex returns** a question (or verdict if satisfied on the current branch)
 3. **Claude researches actively** — read code, grep patterns, consult relevant
    skills, run web searches. Use all available tools: Read, Grep, Glob, Bash,
@@ -201,15 +198,14 @@ Present the summary to the user after posting:
    `c-bpm-sk-grill-me-issue` for disputed points where the user gets grilled
    directly on those branches
 
-## Codex Fallback Chain
+## Judge Availability
 
-1. **Primary**: `codex exec --skip-git-repo-check "<prompt>"`
-2. **Fallback 1**: `gemini` CLI with equivalent prompt
-3. **Fallback 2**: notify user that devil's advocate must be done manually —
-   "Codex and Gemini unavailable. Run the review manually or retry later."
+Invocation and the substitute-Judge ladder belong to `c-bpm-sk-devils-advocate`
+(policy in `c-bpm-sk-llm-selection`). If every tier is unreachable, notify the user
+that the devil's advocate round must be run manually or retried later.
 
-Test availability at session start. If primary fails, switch to fallback
-immediately — do not retry the failed tool on subsequent rounds.
+Test availability at session start. If the primary Judge fails, the ladder switches
+tier immediately — do not retry the failed tool on subsequent rounds.
 
 ## Rules
 

--- a/my/skills/c-bpm-sk-grill-me-issue/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-me-issue/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-grill-me-issue
 description: "Grill a GitHub Issue — grill issue, refine issue, improve issue, sharpen issue, review issue quality. Researches, dedup-checks, validates milestone, and questions relentlessly."
 enforcement: block
@@ -160,13 +159,13 @@ Both paths execute the full wrap-up protocol.
    - Branches resolved (count + list)
    - Branches unresolved (count + list)
    - New issues created (if any, with links)
-3. **Codex Devil's Advocate** review:
-   ```bash
-   codex exec --skip-git-repo-check "Review this refined GitHub Issue #{number}: [title]. Refined content: [summary]. Challenge: 1) Are requirements complete and testable? 2) What edge cases are missing? 3) Is acceptance criteria clear? 4) Any scope creep?"
-   ```
-   Post the Codex response as an issue comment.
-4. **Codex fallback chain**: `codex` -> `gemini` -> notify user that Devil's
-   Advocate review must be done manually.
+3. **Devil's Advocate** review via `c-bpm-sk-devils-advocate` — ask the Judge to
+   challenge the refined Issue #{number}: 1) Are requirements complete and testable?
+   2) What edge cases are missing? 3) Is acceptance criteria clear? 4) Any scope creep?
+   Post the verdict as an issue comment.
+4. **Judge availability**: `c-bpm-sk-devils-advocate` descends the substitute-Judge
+   ladder; if every tier is unreachable, notify the user that the Devil's Advocate
+   review must be done manually.
 
 ## Rules
 

--- a/my/skills/c-bpm-sk-grill-me/SKILL.md
+++ b/my/skills/c-bpm-sk-grill-me/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-grill-me
 description: "Stress-test an idea — grill me, challenge my plan, devil's advocate, poke holes, review my design. Resolves each branch of the decision tree one-by-one through relentless questioning."
 enforcement: block
@@ -180,15 +179,16 @@ When all branches are resolved (or stop signal received):
    (c-bpm-sk-grill-me-issue) take over?" to convert resolved decisions into
    concrete GitHub issues
 
-4. **Codex Devil's Advocate Review** — invoke:
-   ```bash
-   codex exec --skip-git-repo-check "Review this grilled idea documentation: [summary]. Challenge: 1) Are there gaps in the analysis? 2) What assumptions were not questioned? 3) Is the documentation complete enough for someone else to implement? 4) What is the biggest risk that was not addressed?"
-   ```
-   Post the Codex response into the output MD file under a `## Devil's Advocate`
-   heading.
+4. **Devil's Advocate Review** — run it through `c-bpm-sk-devils-advocate`, asking
+   the Judge to challenge the grilled idea documentation: 1) Are there gaps in the
+   analysis? 2) What assumptions were not questioned? 3) Is the documentation
+   complete enough for someone else to implement? 4) What is the biggest risk that
+   was not addressed?
+   Post the verdict into the output MD file under a `## Devil's Advocate` heading.
 
-5. **Codex Fallback Chain** — if `codex` is unavailable, try `gemini`. If both
-   fail, notify the user that the Devil's Advocate review must be done manually.
+5. **Judge availability** — `c-bpm-sk-devils-advocate` descends the substitute-Judge
+   ladder. If every tier is unreachable, notify the user that the Devil's Advocate
+   review must be done manually.
 
 <!-- BEGIN issue-comms (stamped block — do not edit in stamped files; edit my/shared/issue-communication-protocol.md and run scripts/stamp-issue-protocol.sh) -->
 ## Communication: GitHub Issues only

--- a/my/skills/c-bpm-sk-idea-merge/SKILL.md
+++ b/my/skills/c-bpm-sk-idea-merge/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-idea-merge
 description: "Cluster and merge ideas — cluster ideas, merge ideas, find duplicates, group similar issues, clean up ideas, deduplicate. Scans repos (Obsidian vaults, GitHub Issues) for clusterable ideas. User approves each action."
 enforcement: block
@@ -112,20 +111,20 @@ Proposed action: <ACTION_TYPE> — <specific steps>
 
 ## Execution (after user approval per cluster)
 
-### Step 1: Codex Gate
+### Step 1: Judge Gate
 
-Before ANY mutations, invoke Codex for review:
+Before ANY mutations, run the review via `c-bpm-sk-devils-advocate` (Codex primary;
+OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
 
-```bash
-codex exec --skip-git-repo-check \
-  "Review these proposed changes for [repo]: [cluster summary with proposed actions]. \
-   Are groupings warranted? Should any items be split instead? \
-   Missing items that belong in a cluster?"
-```
+> Review these proposed changes for [repo]: [cluster summary with proposed actions].
+> Are groupings warranted? Should any items be split instead?
+> Missing items that belong in a cluster?
 
-Post the Codex response to the user. Only execute if BOTH user AND Codex approve.
+Post the verdict to the user. Only execute if BOTH user AND Judge approve.
 
-**Codex fallback chain:** codex → gemini → notify user (manual review required).
+**If the Judge is unavailable:** `c-bpm-sk-devils-advocate` descends the
+substitute-Judge ladder. If every tier is unreachable, notify the user (manual
+review required).
 
 ### Step 2: Dry-Run Diff
 

--- a/my/skills/c-bpm-sk-jquery-ajax-forms/SKILL.md
+++ b/my/skills/c-bpm-sk-jquery-ajax-forms/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-jquery-ajax-forms
 description: Patterns for safe jQuery form submissions and AJAX requests with CSRF protection, error handling, and user feedback. Use when submitting forms without page reload or performing async UI updates. Derived from S09b.
 ---

--- a/my/skills/c-bpm-sk-library-manager/SKILL.md
+++ b/my/skills/c-bpm-sk-library-manager/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-library-manager
 description: "Library management — c-bpm convention, sync items, push pull library, manage skills, library help. Central knowledge hub for c-bpm- item convention and synchronisation."
 enforcement: block

--- a/my/skills/c-bpm-sk-linux-admin/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-admin/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-linux-admin
 description: "Linux admin fixes — fix audit findings, implement server fixes, Debian/Ubuntu admin, host remediation. Works on bpm-{hostname} repo issues. Agent team with Codex gates."
 user-invocable: true
@@ -211,14 +210,12 @@ Teammate submits plan (via ExitPlanMode)
   → Team Lead reviews plan for safety, completeness, correctness
   → Team Lead posts plan as comment on the GitHub Issue
   → Team Lead updates issue milestone to `planned`
-  → Team Lead executes Codex review:
-
-     codex exec --skip-git-repo-check "Review this Linux administration fix plan
-     for Issue #<N> on a Debian/Ubuntu host. Plan: <plan-summary>.
-     REQUIREMENTS: 1) Pre-checks verify current state. 2) Commands correct for
-     Debian/Ubuntu. 3) Validation confirms fix. 4) Rollback is safe and complete.
+  → Team Lead runs the independent review via `c-bpm-sk-devils-advocate`
+    (Issue #<N>), asking the Judge to check:
+     1) Pre-checks verify current state. 2) Commands correct for Debian/Ubuntu.
+     3) Validation confirms fix. 4) Rollback is safe and complete.
      5) No risk of SSH lockout, data loss, or service disruption.
-     Approve or reject with specific reasons."
+     Approve or reject with specific reasons.
 
   → Codex result posted as comment on the GitHub Issue
   → If BOTH approve → milestone to `plan-approved`, approve teammate's plan
@@ -267,11 +264,10 @@ Team Lead:
   → May run read-only verification commands (exception to delegate mode)
   → Posts verification results as comment on GitHub Issue
 
-Team Lead executes:
-  codex exec --skip-git-repo-check "Verify this Linux administration fix for
-  Issue #<N>. Fix applied: <summary>. Verification: <evidence>.
-  Check: 1) Fix correctly applied. 2) No side effects. 3) Validation genuine.
-  4) System in expected state. Approve or reject with reasons."
+Team Lead runs the independent review via `c-bpm-sk-devils-advocate` (Issue #<N>),
+  asking the Judge to verify the applied fix and the verification evidence:
+  1) Fix correctly applied. 2) No side effects. 3) Validation genuine.
+  4) System in expected state. Approve or reject with reasons.
 
   → If BOTH approve → milestone to `tested-success` → `test-approved` → close issue
   → If EITHER rejects → milestone to `tested-failed`, teammate revises
@@ -292,13 +288,10 @@ After all workable issues are addressed:
 
 2. Post report as comment on the latest Audit Run issue (if one exists)
 
-3. Final Codex review:
-   ```bash
-   codex exec --skip-git-repo-check "Review this Linux administration session
-   report for host {hostname}. Check: 1) All fixes properly verified.
+3. Final independent review via `c-bpm-sk-devils-advocate` — ask the Judge to review
+   the session report for host {hostname}: 1) All fixes properly verified.
    2) No security regressions. 3) System stability maintained.
-   4) Rollback plans documented. Report: {report-content}"
-   ```
+   4) Rollback plans documented.
 
 4. Present final report to user
 
@@ -314,23 +307,19 @@ After all workable issues are addressed:
 
 ## Codex Rules (NON-NEGOTIABLE)
 
-- Independent review is **MANDATORY** for all fixes (Codex primary, Gemini/other as fallback)
-- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check "<prompt>"` (if unavailable, use fallback chain)
-- Independent review is **MANDATORY** at 2 gates (try Codex → Gemini → other): Plan approval (Phase 4), Verification (Phase 6)
+- Independent review is **MANDATORY** for all fixes
+- The Judge MUST be invoked **only through `c-bpm-sk-devils-advocate`** — that skill
+  owns the live-Issue fetch, the canonical sanitized command, and the ladder
+- Independent review is **MANDATORY** at 2 gates: Plan approval (Phase 4), Verification (Phase 6)
 - Log ALL reviewer responses as comments on the corresponding GitHub Issue
 
-### If Codex Is Unavailable
+### If the Judge Is Unavailable
 
-Try the fallback chain before stopping:
-
-1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
-2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
-3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
-
-If ALL models in the chain are unavailable:
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder defined in
+`c-bpm-sk-llm-selection`. If every tier is unreachable:
 - **Notify the user** immediately
 - **Do NOT proceed** without at least one independent review
-- Log which reviewer was used (Codex/Gemini/other) in all review comments
+- Log which reviewer was used in all review comments
 
 ---
 

--- a/my/skills/c-bpm-sk-linux-archive/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-archive/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-linux-archive
 description: "Archive host config — backup dotfiles, save tool configs, host backup, restore setup, config snapshot. Backs up to bpm-{hostname} GitHub repo."
 enforcement: block
@@ -157,15 +156,17 @@ After archiving, update the installed-tools table in MEMORY.md:
 | new-tool | x.y.z | `/path/to/bin` | `~/.config/tool/` |
 ```
 
-## Codex Review Gate
+## Judge Review Gate
 
-Before executing any destructive or irreversible operation (config backup, git commit, git push), submit plan to Codex for review:
+Before executing any destructive or irreversible operation (config backup, git
+commit, git push), run the review via `c-bpm-sk-devils-advocate` (Codex primary;
+OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
 
-```bash
-codex exec --skip-git-repo-check "Review this archive plan: <plan>. Check: no secrets exposed, correct file selection, follows project conventions. Approve or reject."
-```
+> Review this archive plan: `<plan>`. Check: no secrets exposed, correct file
+> selection, follows project conventions. Approve or reject.
 
-If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: STOP and notify the user.
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder when Codex is
+unreachable. If ALL tiers are unreachable: STOP and notify the user.
 
 ## Constraints
 

--- a/my/skills/c-bpm-sk-linux-audit/SKILL.md
+++ b/my/skills/c-bpm-sk-linux-audit/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-linux-audit
 description: "Audit Linux host — server audit, security scan, system health check, host review, onboard server. Creates GitHub Issues per finding in bpm-{hostname}. Agent team with Codex gates."
 user-invocable: true
@@ -123,13 +122,11 @@ Each teammate submits their findings list as a plan.
 ```
 Teammate submits plan (via ExitPlanMode)
   → Team Lead reviews findings
-  → Team Lead executes Codex review:
-
-    codex exec --skip-git-repo-check "Review these Linux audit findings for host {hostname}.
-    Category: {category}. Findings: {findings-summary}.
-    Check: 1) Severity ratings are appropriate. 2) No false positives.
+  → Team Lead runs the independent review via `c-bpm-sk-devils-advocate`, asking the
+    Judge to check the findings for host {hostname}, category {category}:
+    1) Severity ratings are appropriate. 2) No false positives.
     3) Fix steps are correct and safe. 4) Issue types (BUG vs ENHANCEMENT) are correct.
-    Approve or reject with reasons."
+    Approve or reject with reasons.
 
   → If BOTH approve → teammate proceeds to create issues
   → If EITHER rejects → teammate revises findings
@@ -206,16 +203,14 @@ Post as a new issue titled "Audit Run {YYYY-MM-DD}":
 - [x] Local clone synced
 ```
 
-### Codex Final Review
+### Final Independent Review
 
-```bash
-codex exec --skip-git-repo-check "Review this Linux audit summary for host {hostname}.
-Check: 1) All major audit areas covered (runtime, security, health).
-2) Severity ratings consistent. 3) No critical findings missed.
-4) Summary is complete. Summary: {summary-content}"
-```
+Run the review via `c-bpm-sk-devils-advocate`, asking the Judge to check the audit
+summary for host {hostname}: 1) All major audit areas covered (runtime, security,
+health). 2) Severity ratings consistent. 3) No critical findings missed.
+4) Summary is complete.
 
-Post Codex review result as comment on the Audit Run issue.
+Post the verdict as a comment on the Audit Run issue.
 
 ---
 
@@ -276,25 +271,21 @@ No labels. No tags. Issue type + milestone = full lifecycle tracking.
 
 ## Codex Rules (NON-NEGOTIABLE)
 
-- Independent review is **MANDATORY** for all findings (Codex primary, Gemini/other as fallback)
-- Codex MUST be invoked **ONLY via shell**: `codex exec --skip-git-repo-check "<prompt>"` (if unavailable, use fallback chain)
-- Independent review is **MANDATORY** at 2 gates (try Codex → Gemini → other):
+- Independent review is **MANDATORY** for all findings
+- The Judge MUST be invoked **only through `c-bpm-sk-devils-advocate`** — that skill
+  owns the live-Issue fetch, the canonical sanitized command, and the ladder
+- Independent review is **MANDATORY** at 2 gates:
   1. Findings approval (Phase 3)
   2. Audit summary review (Phase 5)
 - Log ALL reviewer responses as comments on the Audit Run issue
 
-### If Codex Is Unavailable
+### If the Judge Is Unavailable
 
-Try the fallback chain before stopping:
-
-1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
-2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
-3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
-
-If ALL models in the chain are unavailable:
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder defined in
+`c-bpm-sk-llm-selection`. If every tier is unreachable:
 - **Notify the user** immediately
 - **Do NOT proceed** without at least one independent review
-- Log which reviewer was used (Codex/Gemini/other) in all review comments
+- Log which reviewer was used in all review comments
 
 ---
 

--- a/my/skills/c-bpm-sk-llm-selection/SKILL.md
+++ b/my/skills/c-bpm-sk-llm-selection/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-llm-selection
 description: "LLM selection and orchestration — choose model, assign agent, agent delegation, consensus finding, model selection, MCP discovery, task decomposition. Task-to-LLM matching, orchestration protocol, and conflict resolution."
 enforcement: block
@@ -17,7 +16,8 @@ How the Orchestrator selects and delegates tasks to available LLMs, and how the 
 |-----|------|-----------|---------|
 | **Claude** | Orchestrator, Primary | Complex reasoning, planning, code review | Orchestration (required), complex tasks, quality-critical work |
 | **Codex** | Implementer | Fast code generation, completions | Routine code tasks, quick completions, high-volume generation |
-| **Gemini** | Substitute Judge (Codex unreachable only) / Large-Context Reader | Large context, multimodal, alternate Judge when Codex is offline | Large document analysis, image processing, substitute Judge in the review loop ONLY when Codex is unreachable |
+| **OpenRouter** | First substitute Judge (Codex unreachable only) | Cheap frontier families (GLM, DeepSeek, Kimi), independent of the Codex account | Substitute Judge in the review loop ONLY when Codex is unreachable — invoked through `c-bpm-sk-devils-advocate` |
+| **Gemini** | Second substitute Judge (Codex and OpenRouter unreachable only) / Large-Context Reader | Large context, multimodal, alternate Judge when Codex is offline | Large document analysis, image processing, substitute Judge in the review loop ONLY when Codex is unreachable |
 
 ## Model Version Policy (single source — referenced everywhere)
 
@@ -26,12 +26,10 @@ command may name a concrete model version; they reference this section.
 
 - **Codex (Judge / implementer):** invoke WITHOUT `-m`. Codex follows its own CLI
   default model. Never pin a Codex model version flag in any skill or command.
-- **Claude teammates:** always the newest Opus (via `model: opus` / inherit). Never
-  pin a numeric Opus version.
-- **OpenRouter (if installed):** for cross-model validation only, and a substitute
-  Judge ONLY when Codex is unreachable (same rule as Gemini). Never a co-Judge,
-  tiebreaker, or third model in the Producer↔Codex loop. Not for daily work (see #47).
-- **Fable:** not yet adopted for production roles (too new). Revisit later.
+- **Claude roles (#112):** Fable is the default Producer and teammate model. Opus is used only where Fable is not a fit — long-horizon orchestration and deep multi-file reasoning. Codex stays the Judge; Producer and Judge are never the same model.
+- **No `model:` key in frontmatter.** Skills and commands do not pin a model in their frontmatter; they inherit the session model and follow THIS section. Model policy is prose here, never a key there.
+- **OpenRouter (first substitute-Judge tier):** when Codex is unreachable, the cheap frontier families on OpenRouter — GLM, DeepSeek, Kimi — take the Judge seat before Gemini. Resolve the newest slug at invocation time from the live catalog (`/api/v1/models`); never pin a numeric version. Never a co-Judge, tiebreaker, or third model in the Producer↔Codex loop.
+- **`OPENROUTER_API_KEY` source:** the user-level `~/.env` exclusively — never a project-level `.env`, never a repo file, never inline in a skill or command.
 - Every other skill and command references THIS section, never names a version.
 
 ## Rules
@@ -44,7 +42,8 @@ command may name a concrete model version; they reference this section.
 ### Task Delegation
 1. **Default to Claude** for complex, quality-critical, or ambiguous tasks
 2. **Use Codex** for straightforward code generation when speed matters
-3. **Use Gemini** for large-context or multimodal tasks, or as the substitute Judge in the Producer↔Codex review loop ONLY when Codex is unreachable (network outage, auth failure, binary missing). Never as a co-Judge alongside Codex. Never as a tiebreaker.
+3. **Use Gemini** for large-context or multimodal tasks, or as the substitute Judge in the Producer↔Codex review loop ONLY when Codex and OpenRouter are both unreachable (network outage, auth failure, binary missing). Never as a co-Judge alongside Codex. Never as a tiebreaker.
+4. **Invoke the Judge only through `c-bpm-sk-devils-advocate`** — that skill owns the live-Issue fetch, the canonical sanitized command, and the substitute-Judge ladder. No other skill or command calls the Judge CLI itself.
 
 ## Codex Review Loop (Producer ↔ Judge)
 
@@ -85,7 +84,7 @@ This is the canonical review pattern for every artifact produced in this library
 
 **Non-Codex Judge — guard rails**
 
-The fallback chain (Codex → Gemini → next available independent model) exists
+The fallback chain (Codex → OpenRouter cheap frontier → Gemini → next available independent model) exists
 ONLY for the case where Codex itself cannot be reached. The following rules are
 absolute and must not be relaxed:
 
@@ -94,8 +93,9 @@ absolute and must not be relaxed:
   service down. It substitutes for Codex in the Judge role; it is never run
   alongside Codex as a second opinion or co-reviewer.
 - **One Judge at a time.** The fallback chain runs sequentially: try Codex; if
-  Codex is unreachable, try Gemini; if Gemini is unreachable, try the next
-  available independent model. At any given step there is exactly one active
+  Codex is unreachable, try OpenRouter (cheap frontier); if OpenRouter is
+  unreachable, try Gemini; if Gemini is unreachable, try the next available
+  independent model. At any given step there is exactly one active
   Judge. Never two Judges concurrently.
 - **Never a tiebreaker.** A non-Codex Judge is NEVER invoked to break a deadlock
   between Producer and Codex. If Codex is reachable and rejects, the Producer
@@ -111,11 +111,10 @@ consistent with it.
 
 ## Codex Invocation (shell hygiene)
 
-This is the canonical shell form for invoking the Codex Judge — the form the Team
-Lead uses at review gates and that new skills should adopt. Migrating the existing
-inline `codex exec` examples across the library to this sanitized form is tracked in
-#94 (in progress); until that lands, those call sites remain the plain
-`codex exec --skip-git-repo-check` form.
+This is the canonical shell form for invoking the Codex Judge. Since #113 it lives
+in exactly two places — this section (the policy) and `c-bpm-sk-devils-advocate`
+(the operational skill that every gate calls). No other skill or command carries an
+inline invocation; they delegate to `c-bpm-sk-devils-advocate` instead.
 
 **Problem it solves (issue #94):** Codex's captured output must contain *only*
 Codex's verdict. When `codex exec` is run from a login/rc-sourcing shell, the
@@ -127,11 +126,14 @@ Codex's own internal shells inherit the parent environment, the fix is to clear
 `BASH_ENV`/`ENV` and disable profile/rc in the invoking shell so nothing
 downstream re-sources them.
 
-**Canonical form** — sanitized, non-login shell, prompt on stdin:
+**Canonical form** — sanitized, non-login shell, network-enabled workspace
+sandbox, Issue-sourced prompt on stdin:
 
 ```bash
-env -u BASH_ENV -u ENV bash --noprofile --norc -c \
-  'codex exec --skip-git-repo-check < prompt.md 2>&1'
+{ gh api repos/${OWNER}/${REPO}/issues/${N} --jq .body
+  gh api repos/${OWNER}/${REPO}/issues/${N}/comments --jq '.[].body'
+} | env -u BASH_ENV -u ENV bash --noprofile --norc -c \
+  'codex exec --skip-git-repo-check -s workspace-write -c sandbox_workspace_write.network_access=true 2>&1'
 ```
 
 **Rules**
@@ -140,8 +142,15 @@ env -u BASH_ENV -u ENV bash --noprofile --norc -c \
   that cause non-interactive shells (including Codex's own) to source rc files.
 - **No login/rc shell.** `bash --noprofile --norc` — never `bash -l`, `bash -lc`,
   or any shell that sources `~/.bash_profile` / `~/.bashrc` / `~/.profile`.
-- **Prompt on stdin.** Pass the review prompt via `< prompt.md`, never as a large
-  inline argv (it hangs).
+- **Sandbox with network (issue #117).** `-s workspace-write` plus
+  `-c sandbox_workspace_write.network_access=true` — the read-only default sandbox
+  makes the Judge unable to read the workspace or reach the network, which it
+  reports as an inability to review. `danger-full-access` is never sanctioned;
+  workspace-write is the ceiling.
+- **Token order is load-bearing.** `codex exec --skip-git-repo-check` stays
+  contiguous and the sandbox flags follow it, so the guard suites keep matching.
+- **Prompt on stdin, Issue-sourced.** Pipe the Issue body and its comments in on
+  stdin — never a large inline argv (it hangs), and never an authored `.md`.
 - **Verdict-only output.** A clean invocation emits only Codex's review verdict —
   no `keychain`, `ssh-agent`, or `curl` startup lines.
 

--- a/my/skills/c-bpm-sk-mariadb-migrations/SKILL.md
+++ b/my/skills/c-bpm-sk-mariadb-migrations/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-mariadb-migrations
 description: "MariaDB migration — database migration, alter table, add column, schema change, SQL migration. Forward-only migration pattern with safe schema changes."
 enforcement: block

--- a/my/skills/c-bpm-sk-milestone-type/SKILL.md
+++ b/my/skills/c-bpm-sk-milestone-type/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-milestone-type
 description: "Milestone and issue type enforcement — audit milestones, fix issue labels, ensure bug/enhancement, compliance check. Ensures every issue has milestone + type label."
 enforcement: block
@@ -218,48 +217,38 @@ Open issues: 12
 7. **Audit trail** — every reviewer response (Codex/Gemini/other) posted as comment on the GitHub Issue
 8. **Check existing issues** before creating new ones to avoid duplicates
 
-## Codex Gate Patterns
+## Judge Gate Patterns
+
+Every gate below is run through `c-bpm-sk-devils-advocate` — it fetches the live
+Issue and invokes the Judge with the canonical sanitized command. The gate owner
+supplies only what the Judge must check.
 
 ### Gate 1: Plan Approval (planned -> plan-approved)
 
-```bash
-codex exec --skip-git-repo-check "Review this implementation plan for Issue #<N>. \
-Plan: <plan-summary>. \
-REQUIREMENTS: 1) Test coverage must be included. 2) Changes scoped to assigned files. \
-3) Risk assessment present. 4) Rollback strategy present. \
-Approve or reject with specific reasons."
-```
+Ask the Judge to review the implementation plan for Issue #<N>:
+1) Test coverage must be included. 2) Changes scoped to assigned files.
+3) Risk assessment present. 4) Rollback strategy present.
+Approve or reject with specific reasons.
 
 ### Gate 2: Test Design Approval (test-designed -> test-design-approved)
 
-```bash
-codex exec --skip-git-repo-check "Review test design for Issue #<N>. \
-Tests: <test-description>. \
-Check: edge cases covered, meaningful assertions, no false positives, \
-adequate coverage, follows project test framework. Approve or reject."
-```
+Ask the Judge to review the test design for Issue #<N>: edge cases covered,
+meaningful assertions, no false positives, adequate coverage, follows the project
+test framework. Approve or reject.
 
 ### Gate 3: Test Verification (tested-success -> test-approved)
 
-```bash
-codex exec --skip-git-repo-check "Verify implementation and test results for Issue #<N>. \
-Changes: <summary>. \
-Check: tests passing legitimately, no false positives, test coverage adequate, \
-code quality acceptable. Approve or reject."
-```
+Ask the Judge to verify implementation and test results for Issue #<N>: tests
+passing legitimately, no false positives, test coverage adequate, code quality
+acceptable. Approve or reject.
 
-### If Codex Is Unavailable
+### If the Judge Is Unavailable
 
-Try the fallback chain before stopping:
-
-1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
-2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
-3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
-
-If ALL models in the chain are unavailable:
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder defined in
+`c-bpm-sk-llm-selection`. If every tier is unreachable:
 - **Notify the user** immediately
 - **Do NOT proceed** without at least one independent review
-- Log which reviewer was used (Codex/Gemini/other) in all review comments
+- Log which reviewer was used in all review comments
 
 ## Milestone Transitions via GitHub MCP
 

--- a/my/skills/c-bpm-sk-n8n-reliability/SKILL.md
+++ b/my/skills/c-bpm-sk-n8n-reliability/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-n8n-reliability
 description: "n8n workflow patterns — create n8n workflow, reliable workflow, version n8n, export workflow, multi-env deploy. Maintainable and versionable n8n workflows."
 enforcement: block

--- a/my/skills/c-bpm-sk-php-crud-api-review/SKILL.md
+++ b/my/skills/c-bpm-sk-php-crud-api-review/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-php-crud-api-review
 description: "php-crud-api review — evaluate php-crud-api, API integration review, mevdschee crud, auto-generated REST. Security review and integration guidance."
 enforcement: block

--- a/my/skills/c-bpm-sk-php-flight-mvc/SKILL.md
+++ b/my/skills/c-bpm-sk-php-flight-mvc/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-php-flight-mvc
 description: Conventions for PHP backend applications using Flight microframework in MVC style. Use when starting a new PHP service with Flight, refactoring to modular structure, or reviewing contributions. Basis skill — my-flightphp-pro is the extended version. Derived from S05.
 ---

--- a/my/skills/c-bpm-sk-question-auditor/SKILL.md
+++ b/my/skills/c-bpm-sk-question-auditor/SKILL.md
@@ -119,13 +119,15 @@ For every question, check:
 - Question must test knowledge someone needs to know for the certification
 - Obscure trivia or unrelated knowledge = IRRELEVANT
 
-### Step 6: Codex Escalation
+### Step 6: Judge Escalation
 
-For ambiguous cases (especially answer correctness):
+For ambiguous cases (especially answer correctness), run the review via
+`c-bpm-sk-devils-advocate` (Codex primary; OpenRouter fallback per
+`c-bpm-sk-llm-selection`), asking the Judge:
 
-```bash
-codex exec --skip-git-repo-check "Evaluate this exam question. Is the answer marking correct? Question: ${Q_TEXT} Answer: ${A_TEXT} Marked as: ${IS_CORRECT}. Topic context: ${TOPIC_NAME}. Respond: CORRECT, INCORRECT, or AMBIGUOUS with evidence."
-```
+> Evaluate this exam question. Is the answer marking correct? Question: `${Q_TEXT}`
+> Answer: `${A_TEXT}` Marked as: `${IS_CORRECT}`. Topic context: `${TOPIC_NAME}`.
+> Respond: CORRECT, INCORRECT, or AMBIGUOUS with evidence.
 
 ### Step 7: Generate Report
 

--- a/my/skills/c-bpm-sk-redis-keyspace/SKILL.md
+++ b/my/skills/c-bpm-sk-redis-keyspace/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-redis-keyspace
 description: "Redis keyspace — Redis keys, caching strategy, TTL policy, distributed lock, rate limiting, Redis queue. Naming conventions and operational patterns."
 enforcement: block

--- a/my/skills/c-bpm-sk-release-ops/SKILL.md
+++ b/my/skills/c-bpm-sk-release-ops/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-release-ops
 description: "Release operations — cut a release, versioning, CI/CD setup, deployment, rollback, artefact packaging. Controlled release process and deployment playbooks."
 enforcement: block
@@ -48,15 +47,16 @@ jobs:
           path: release.zip
 ```
 
-## Codex Review Gate
+## Judge Review Gate
 
-Before executing any destructive or irreversible operation (release cut, tag creation, artefact publishing), submit plan to Codex for review:
+Before executing any destructive or irreversible operation (release cut, tag
+creation, artefact publishing), run the review via `c-bpm-sk-devils-advocate`
+(Codex primary; OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
 
-```bash
-codex exec --skip-git-repo-check "Review this release plan: <plan>. Check: correct versioning, no breaking changes, follows project conventions. Approve or reject."
-```
+> Review this release plan: `<plan>`. Check: correct versioning, no breaking
+> changes, follows project conventions. Approve or reject.
 
-If Codex is unavailable: STOP and notify the user.
+If every tier of the substitute-Judge ladder is unreachable: STOP and notify the user.
 
 ## Success Criteria
 

--- a/my/skills/c-bpm-sk-repo-scaffold/SKILL.md
+++ b/my/skills/c-bpm-sk-repo-scaffold/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-repo-scaffold
 description: "Scaffold a repo — new project, project structure, directory layout, init repo, repository template, Excalidraw diagrams. Consistent starting point with baseline files."
 enforcement: block
@@ -43,15 +42,18 @@ Provide a consistent starting point for new projects, ensuring that directory la
 └── README.md
 ```
 
-## Codex Review Gate
+## Judge Review Gate
 
-Before executing any destructive or irreversible operation (directory scaffolding, file overwriting, project restructuring), submit plan to Codex for review:
+Before executing any destructive or irreversible operation (directory scaffolding,
+file overwriting, project restructuring), run the review via
+`c-bpm-sk-devils-advocate` (Codex primary; OpenRouter fallback per
+`c-bpm-sk-llm-selection`), asking the Judge:
 
-```bash
-codex exec --skip-git-repo-check "Review this scaffold plan: <plan>. Check: correct structure, no breaking changes, follows project conventions. Approve or reject."
-```
+> Review this scaffold plan: `<plan>`. Check: correct structure, no breaking
+> changes, follows project conventions. Approve or reject.
 
-If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: STOP and notify the user.
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder when Codex is
+unreachable. If ALL tiers are unreachable: STOP and notify the user.
 
 ## Success Criteria
 

--- a/my/skills/c-bpm-sk-skill-creator/SKILL.md
+++ b/my/skills/c-bpm-sk-skill-creator/SKILL.md
@@ -5,7 +5,6 @@ description: >
   "add skill", "build skill", or wants to create a new Claude Code skill from scratch or fork
   an existing one. Skills 2.0 features, auto-detects existing c-bpm-sk- versions. Delegates
   to optimizer if found. Enforces naming and Codex review.
-model: opus
 enforcement: block
 intentPatterns: "create (a |new )?skill;;new skill;;make (a )?skill;;build (a )?skill;;add (a )?skill"
 user-invocable: true
@@ -117,21 +116,24 @@ model: opus                        # If specific model needed
 
 Create scripts, references, assets as identified in Step 2.
 
-### Step 5: Codex Review
+### Step 5: Judge Review
 
-```bash
-codex exec --skip-git-repo-check "Review this Claude Code skill for Skills 2.0 compliance. Check:
-1. Frontmatter: name (c-bpm-sk- prefix), description (triggers), Skills 2.0 fields
-2. Progressive disclosure: SKILL.md under 500 lines, references split out
-3. No duplication between SKILL.md and reference files
-4. Examples are concrete and minimal
-5. Constraints are actionable (MUST/MUST NOT)
-6. No unnecessary files (README.md, CHANGELOG.md, etc.)
-7. Original skill untouched (if forked)
-Skill content: <skill content>"
-```
+Run the review via `c-bpm-sk-devils-advocate` (Codex primary; OpenRouter fallback
+per `c-bpm-sk-llm-selection`), asking the Judge to review the skill for Skills 2.0
+compliance:
 
-If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: notify user, do not proceed without independent review. Log which reviewer was used.
+> 1. Frontmatter: name (c-bpm-sk- prefix), description (triggers), Skills 2.0 fields
+> 2. Progressive disclosure: SKILL.md under 500 lines, references split out
+> 3. No duplication between SKILL.md and reference files
+> 4. Examples are concrete and minimal
+> 5. Constraints are actionable (MUST/MUST NOT)
+> 6. No unnecessary files (README.md, CHANGELOG.md, etc.)
+> 7. Original skill untouched (if forked)
+> Skill content: `<skill content>`
+
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder when Codex is
+unreachable. If every tier is unreachable: notify user, do not proceed without
+independent review. Log which Judge produced the verdict.
 
 ### Step 6: Iterate
 

--- a/my/skills/c-bpm-sk-skill-optimizer/SKILL.md
+++ b/my/skills/c-bpm-sk-skill-optimizer/SKILL.md
@@ -5,7 +5,6 @@ description: >
   "refactor skill", "upgrade skill", "enhance skill", "add Skills 2.0 features to a skill",
   or wants to audit an existing skill against the Skills 2.0 checklist. Adds frontmatter,
   supporting files, dynamic context, subagent config. Enforces c-bpm- naming.
-model: opus
 enforcement: block
 intentPatterns: "optimize (a |this )?skill;;improve (a |this )?skill;;refactor (a |this )?skill;;upgrade skill;;skills 2\.0 (feature|checklist)"
 user-invocable: true
@@ -106,19 +105,22 @@ Document what will change and why. Present to user for approval.
 4. Move large sections to supporting files if needed
 5. Add scripts to `scripts/` if `${CLAUDE_SKILL_DIR}` references needed
 
-### Step 4: Codex Review
+### Step 4: Judge Review
 
-```bash
-codex exec --skip-git-repo-check "Review this Claude Code skill for Skills 2.0 compliance. Check:
-2. SKILL.md under 500 lines, references split out
-3. No duplication between SKILL.md and reference files
-4. Dynamic context injection used where beneficial
-5. Supporting files properly referenced
-6. Naming convention (c-bpm-sk- prefix for custom skills)
-Skill content: <skill content>"
-```
+Run the review via `c-bpm-sk-devils-advocate` (Codex primary; OpenRouter fallback
+per `c-bpm-sk-llm-selection`), asking the Judge to review the skill for Skills 2.0
+compliance:
 
-If Codex is unavailable, try the fallback chain: Codex → Gemini (`gemini` CLI) → any available model. If ALL unavailable: notify user, do not proceed without independent review. Log which reviewer was used.
+> 2. SKILL.md under 500 lines, references split out
+> 3. No duplication between SKILL.md and reference files
+> 4. Dynamic context injection used where beneficial
+> 5. Supporting files properly referenced
+> 6. Naming convention (c-bpm-sk- prefix for custom skills)
+> Skill content: `<skill content>`
+
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder when Codex is
+unreachable. If every tier is unreachable: notify user, do not proceed without
+independent review. Log which Judge produced the verdict.
 
 Follow `c-bpm-sk-milestone-type` for issue lifecycle and type enforcement when creating or tracking issues.
 

--- a/my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md
+++ b/my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md
@@ -162,10 +162,12 @@ The teammate posts a plan as a comment on their assigned issue. The plan must in
 ### Dual Review
 
 1. **Team Lead reviews** — Checks scope, naming convention, segregation of duty
-2. **Codex reviews** — Run:
-   ```bash
-   codex exec --skip-git-repo-check "Review this skill development plan. Check for: naming convention (c-bpm-sk- prefix), segregation of duty (original untouched), frontmatter quality, progressive disclosure, no unnecessary files. Plan: <plan content>"
-   ```
+2. **The Judge reviews** — run the review via `c-bpm-sk-devils-advocate` (Codex
+   primary; OpenRouter fallback per `c-bpm-sk-llm-selection`), asking the Judge:
+
+   > Review this skill development plan. Check for: naming convention (c-bpm-sk-
+   > prefix), segregation of duty (original untouched), frontmatter quality,
+   > progressive disclosure, no unnecessary files. Plan: `<plan content>`
 
 ### Approval
 
@@ -198,20 +200,20 @@ When implementation is complete, move issue to milestone: `implemented`.
 
 ## Phase 5 — Codex Review & Verification
 
-### Codex Skill Review
+### Judge Skill Review
 
-```bash
-codex exec --skip-git-repo-check "Review this Claude Code skill for quality. Check for:
-1. Frontmatter: name and description are clear, description includes trigger conditions
-2. Progressive disclosure: SKILL.md under 500 lines, references split out properly
-3. No duplication between SKILL.md and reference files
-4. Examples are concrete and minimal, not verbose explanations
-5. Constraints are actionable (MUST/MUST NOT), not vague guidelines
-6. No unnecessary files (README.md, CHANGELOG.md, etc.)
-7. Naming convention: c-bpm-sk- prefix for custom skills
-8. Segregation: original skill untouched
-Skill content: <skill content>"
-```
+Run the review via `c-bpm-sk-devils-advocate` (Codex primary; OpenRouter fallback
+per `c-bpm-sk-llm-selection`), asking the Judge to review the skill for quality:
+
+> 1. Frontmatter: name and description are clear, description includes trigger conditions
+> 2. Progressive disclosure: SKILL.md under 500 lines, references split out properly
+> 3. No duplication between SKILL.md and reference files
+> 4. Examples are concrete and minimal, not verbose explanations
+> 5. Constraints are actionable (MUST/MUST NOT), not vague guidelines
+> 6. No unnecessary files (README.md, CHANGELOG.md, etc.)
+> 7. Naming convention: c-bpm-sk- prefix for custom skills
+> 8. Segregation: original skill untouched
+> Skill content: `<skill content>`
 
 ### Verification Checks
 
@@ -250,13 +252,12 @@ Present a synthesis report to the user:
 
 ### Invocation
 
-Codex is invoked ONLY via:
+The Judge is invoked ONLY through `c-bpm-sk-devils-advocate` (Codex primary;
+OpenRouter fallback per `c-bpm-sk-llm-selection`). That skill owns the live-Issue
+fetch, the canonical sanitized command, and the substitute-Judge ladder.
 
-```bash
-codex exec --skip-git-repo-check "<review prompt>"
-```
-
-Never use interactive mode. Never skip independent review at mandatory gates (use fallback chain if Codex unavailable).
+Never use interactive mode. Never skip independent review at mandatory gates (the
+skill descends the ladder if Codex is unreachable).
 
 ### Mandatory Review Gates
 
@@ -265,15 +266,16 @@ Independent review (Codex → Gemini → other) is required at exactly 2 gates:
 1. **Plan approval** (Phase 3) — Reviews the development plan
 2. **Skill review** (Phase 5) — Reviews the implemented skill
 
-### If Codex Is Unavailable
+### If the Judge Is Unavailable
 
-Try the fallback chain before stopping:
+`c-bpm-sk-devils-advocate` descends the substitute-Judge ladder defined in
+`c-bpm-sk-llm-selection`:
 
-1. **Primary:** `codex exec --skip-git-repo-check "<prompt>"`
-2. **Fallback 1:** `gemini "<prompt>"` (Gemini CLI)
-3. **Fallback 2:** Any available model that can serve as devil's advocate reviewer
+1. **Primary:** Codex
+2. **Fallback 1:** OpenRouter cheap frontier
+3. **Fallback 2:** Gemini, then the next available independent model
 
-If ALL models in the chain are unavailable:
+If ALL tiers in the ladder are unreachable:
 - **Notify the user** immediately
 - **Do NOT proceed** without at least one independent review
 - Log which reviewer was used (Codex/Gemini/other) in all review comments

--- a/my/skills/c-bpm-sk-test-harness/SKILL.md
+++ b/my/skills/c-bpm-sk-test-harness/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-test-harness
 description: "Test harness — write tests, create test suite, test coverage, CI testing, Bash/PHP/API tests. Consistent approach to building and running tests."
 enforcement: block

--- a/my/skills/c-bpm-sk-tls-http-headers/SKILL.md
+++ b/my/skills/c-bpm-sk-tls-http-headers/SKILL.md
@@ -1,5 +1,4 @@
 ---
-model: opus
 name: c-bpm-sk-tls-http-headers
 description: "TLS and HTTP headers — SSL config, security headers, reverse proxy, HTTPS setup, XSS protection, clickjacking. Baseline TLS and header configuration."
 enforcement: block

--- a/tests/bash/c-bpm-cm-goal-issue.bats
+++ b/tests/bash/c-bpm-cm-goal-issue.bats
@@ -1,0 +1,289 @@
+#!/usr/bin/env bats
+#
+# c-bpm-cm-goal-issue.bats - Content guards for the GOAL ISSUE command (Issue #112)
+# Run with: bats tests/bash/c-bpm-cm-goal-issue.bats
+#
+# Scope: static content guards on my/commands/c-bpm-cm-goal-issue.md only.
+# The 14 tests below implement the Codex-approved "Implementation Plan v2"
+# coverage list from Issue #112. Two of them lock in the policy precedences
+# that Codex required (no `model:` frontmatter key; SUMMARY artifact only
+# allowed together with its explicit precedence statement).
+#
+# NOTE: every grep is scoped to ${CMD} (a path under my/), never to a
+# directory tree, so the guard patterns in this file cannot match themselves.
+#
+# Byte-identity of the issue-communication block is covered by
+# issue-comms-anchor.bats; codex invocation hygiene by
+# c-bpm-sk-codex-invocation-hygiene.bats. Not duplicated here.
+
+set -u
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+  CMD="${REPO_ROOT}/my/commands/c-bpm-cm-goal-issue.md"
+}
+
+# Extract the first `---` .. `---` YAML frontmatter block (exclusive of fences).
+frontmatter() {
+  awk '
+    NR == 1 && $0 == "---" { inblock = 1; next }
+    inblock && $0 == "---"  { exit }
+    inblock                 { print }
+  ' "$1"
+}
+
+# The SUMMARY section: the line naming the report file plus its surrounding
+# context. Tests 12 and 13 are coupled through this window, so the precedence
+# statement must live WITH the artifact, not somewhere else in the file.
+SUMMARY_FILE_RE='SUMMARY-(<YYYYMMDD>-<HHMM>|%Y%m%d-%H%M|\$\(date[^)]*\))\.md'
+
+summary_window() {
+  grep -E -B2 -A15 "${SUMMARY_FILE_RE}" "$1" || true
+}
+
+# Clean guard so a missing command file fails as an assertion, not a script error.
+require_cmd() {
+  if [[ ! -f "${CMD}" ]]; then
+    printf 'Command file not found: my/commands/c-bpm-cm-goal-issue.md\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 1 — the command file exists
+# ------------------------------------------------------------------
+
+@test "1: my/commands/c-bpm-cm-goal-issue.md exists" {
+  require_cmd
+}
+
+# ------------------------------------------------------------------
+# 2 — frontmatter carries name + a trigger-rich description
+# ------------------------------------------------------------------
+
+@test "2: frontmatter declares name and a trigger-rich description" {
+  require_cmd
+  local fm
+  fm="$(frontmatter "${CMD}")"
+
+  if [[ -z "${fm}" ]]; then
+    printf 'No YAML frontmatter block found at the top of the command file.\n' >&2
+    return 1
+  fi
+  if ! printf '%s\n' "${fm}" | grep -qE '^name:[[:space:]]*c-bpm-cm-goal-issue[[:space:]]*$'; then
+    printf 'Frontmatter must declare: name: c-bpm-cm-goal-issue\n' >&2
+    return 1
+  fi
+  if ! printf '%s\n' "${fm}" | grep -qE '^description:[[:space:]]*\S'; then
+    printf 'Frontmatter must declare a non-empty description.\n' >&2
+    return 1
+  fi
+  if ! printf '%s\n' "${fm}" | grep -qiE '^description:.*(overnight|unattended|goal issue|nachtlauf)'; then
+    printf 'Description must contain trigger keywords (overnight/unattended/goal issue/nachtlauf).\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 3 — NO `model:` key in frontmatter (single-source model policy, #98)
+#     Codex directive D2: model selection is owned by c-bpm-sk-llm-selection.
+# ------------------------------------------------------------------
+
+@test "3: frontmatter contains NO 'model:' key (single-source model policy)" {
+  require_cmd
+  local bad
+  bad="$(frontmatter "${CMD}" | grep -n '^model:' || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'Frontmatter must NOT hard-wire a model. Found:\n%s\n' "${bad}" >&2
+    printf 'Model selection is owned solely by c-bpm-sk-llm-selection.\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 4 — no numeric model version pin anywhere in the command
+# ------------------------------------------------------------------
+
+@test "4: no numeric model version pin (fable/codex + digit) in the command" {
+  require_cmd
+  local bad
+  bad="$(grep -niE '(fable|codex)[- ]?[0-9]' "${CMD}" || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'Hard-wired numeric model version found in the command:\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 5 — defers model selection to the single source of truth
+# ------------------------------------------------------------------
+
+@test "5: references c-bpm-sk-llm-selection as the model authority" {
+  require_cmd
+  if ! grep -qF 'c-bpm-sk-llm-selection' "${CMD}"; then
+    printf 'Command must reference c-bpm-sk-llm-selection for all model selection.\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 6 — final devil's-advocate pass is wired in by exact skill name
+# ------------------------------------------------------------------
+
+@test "6: references c-bpm-sk-devils-advocate for the final review pass" {
+  require_cmd
+  if ! grep -qF 'c-bpm-sk-devils-advocate' "${CMD}"; then
+    printf 'Command must reference c-bpm-sk-devils-advocate (created by #113, same branch).\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 7 — batch execution delegates to the existing team command
+# ------------------------------------------------------------------
+
+@test "7: delegates batch execution to c-bpm-cm-openissues-team" {
+  require_cmd
+  if ! grep -qF 'c-bpm-cm-openissues-team' "${CMD}"; then
+    printf 'Command must delegate batch execution to /c-bpm-cm-openissues-team.\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 8 — scope contract: $ARGUMENTS plus default milestone `new`
+# ------------------------------------------------------------------
+
+@test "8: scope contract uses \$ARGUMENTS and defaults to milestone 'new'" {
+  require_cmd
+  if ! grep -qF '$ARGUMENTS' "${CMD}"; then
+    printf 'Command must accept scope via $ARGUMENTS.\n' >&2
+    return 1
+  fi
+  # One explicit default-scope line: it must say "default", "milestone" and "new"
+  # together — not three unrelated mentions scattered across the file.
+  if ! grep -i 'default' "${CMD}" | grep -i 'milestone' | grep -qiE '\bnew\b'; then
+    printf 'Command must carry ONE explicit default-scope line naming default + milestone + new.\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 9 — autonomy contract: never ask; no blocking wait for user confirmation
+# ------------------------------------------------------------------
+
+@test "9: autonomy contract present (never ask the user, no blocking wait)" {
+  require_cmd
+  if ! grep -qiE 'never asks? the user' "${CMD}"; then
+    printf 'Autonomy contract missing: the command must state it NEVER asks THE USER.\n' >&2
+    return 1
+  fi
+  local hits bad=""
+  hits="$(grep -niE 'wait(s|ed|ing)? for (the )?user (confirmation|approval)' "${CMD}" || true)"
+  if [[ -n "${hits}" ]]; then
+    # Only a negation that PRECEDES the phrase on the SAME line makes the mention
+    # harmless ("never waits for user confirmation"). Trailing/loose qualifiers
+    # ("override prior autonomy and wait for user confirmation") do not.
+    bad="$(printf '%s\n' "${hits}" \
+          | grep -viE "(never|does not|do not|don.t|without)[[:space:]].*wait(s|ed|ing)? for (the )?user (confirmation|approval)" || true)"
+  fi
+  if [[ -n "${bad}" ]]; then
+    printf 'Blocking user-confirmation instruction found (breaks unattended run):\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 10 — direct-to-main commit contract (PC-2, ratified precedence)
+# ------------------------------------------------------------------
+
+@test "10: direct-to-main contract (one commit per issue, push to main, no PRs)" {
+  require_cmd
+  local missing="" commit_ctx
+  # 'one commit per issue' must sit in an actual commit/push context, not in a
+  # stray prose line elsewhere in the document.
+  commit_ctx="$(grep -i -B1 -A1 'one commit per issue' "${CMD}" || true)"
+  if [[ -z "${commit_ctx}" ]] || ! printf '%s\n' "${commit_ctx}" | grep -qiE '(push|main|git commit)'; then
+    missing="${missing} 'one commit per issue' in commit/push/main context"
+  fi
+  grep -qiE '(direct(ly)?[- ]to[- ](the )?main|push(es|ed)? to (the )?main|commit(s|ted)? (direct(ly)?)? ?to (the )?main)' "${CMD}" \
+    || missing="${missing} direct-to-main push statement"
+  grep -qiE 'no (PRs?|pull requests?)' "${CMD}" || missing="${missing} 'no PRs' statement"
+  if [[ -n "${missing}" ]]; then
+    printf 'Direct-to-main contract incomplete, missing:%s\n' "${missing}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 11 — DoD gate: test-approved required, DONE stays human-only
+# ------------------------------------------------------------------
+
+@test "11: commit gate requires 'test-approved' and keeps DONE human-only" {
+  require_cmd
+  if ! grep -qF 'test-approved' "${CMD}"; then
+    printf 'Command must gate commits on the test-approved milestone.\n' >&2
+    return 1
+  fi
+  # 'human-only' must qualify DONE on the very same line.
+  if ! grep -iE 'human[- ]only' "${CMD}" | grep -qiE '\bDONE\b'; then
+    printf 'Command must state on one line that DONE is human-only (agents never set it).\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 12 — SUMMARY artifact filename pattern
+# ------------------------------------------------------------------
+
+@test "12: final report uses the SUMMARY-<YYYYMMDD>-<HHMM>.md filename pattern" {
+  require_cmd
+  if ! grep -qE "${SUMMARY_FILE_RE}" "${CMD}"; then
+    printf 'Command must name the final report SUMMARY-<YYYYMMDD>-<HHMM>.md\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 13 — SUMMARY precedence statement (Codex directive D1)
+#      Pairs with test 12: the side-car artifact is only allowed together
+#      with its explicit, documented precedence over the issues-only rule.
+# ------------------------------------------------------------------
+
+@test "13: SUMMARY artifact carries the explicit precedence statement" {
+  require_cmd
+  local missing="" window
+  window="$(summary_window "${CMD}")"
+  if [[ -z "${window}" ]]; then
+    printf 'No SUMMARY section found — cannot verify the precedence statement.\n' >&2
+    return 1
+  fi
+  # Markers must sit INSIDE the SUMMARY section, not anywhere in the document.
+  printf '%s\n' "${window}" | grep -qiF 'takes precedence' || missing="${missing} 'takes precedence'"
+  printf '%s\n' "${window}" | grep -qiF 'authoritative'    || missing="${missing} 'authoritative'"
+  printf '%s\n' "${window}" | grep -qiE 'issue comments?'  || missing="${missing} 'issue comment'"
+  if [[ -n "${missing}" ]]; then
+    printf 'SUMMARY precedence block incomplete, missing marker(s):%s\n' "${missing}" >&2
+    printf 'Required: #112 spec takes precedence for this single artifact; Issues stay\n' >&2
+    printf 'authoritative; every per-issue fact is posted as an issue comment FIRST.\n' >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 14 — DoD is the loop exit condition, with a documented-blocked escape
+# ------------------------------------------------------------------
+
+@test "14: loop exit condition is DoD-met or documented-blocked" {
+  require_cmd
+  if ! grep -iE '(exit|terminat|stop|end)' "${CMD}" | grep -qiE '\bDoD\b|definition of done'; then
+    printf 'Loop exit condition must be stated in terms of the DoD.\n' >&2
+    return 1
+  fi
+  # The escape hatch must be the literal `documented-blocked` state, and it must
+  # appear in exit/stall context — not as a stray "blocked" anywhere in the file.
+  if ! grep -iE '(exit|stall|terminat|stop|end of)' "${CMD}" | grep -qiF 'documented-blocked'; then
+    printf 'Loop must name the literal documented-blocked escape in its exit/stall condition.\n' >&2
+    return 1
+  fi
+}

--- a/tests/bash/c-bpm-sk-devils-advocate.bats
+++ b/tests/bash/c-bpm-sk-devils-advocate.bats
@@ -1,0 +1,503 @@
+#!/usr/bin/env bats
+#
+# c-bpm-sk-devils-advocate.bats - Issue #113 (+ #112, #117) acceptance suite
+# Run with: bats tests/bash/c-bpm-sk-devils-advocate.bats
+#
+# Purpose:
+#   Issue #113 centralises the Codex-as-Judge invocation into ONE skill,
+#   c-bpm-sk-devils-advocate, and makes c-bpm-sk-llm-selection the single
+#   source of model/ladder policy. This suite locks in:
+#     1. Every enumerated call site had its direct `codex exec` invocation
+#        REMOVED (not merely annotated) and delegates to the new skill.
+#        Reference files are checked on RAW content (they carry no legitimate
+#        stamped block); SKILL.md files must carry EXACTLY ONE stamped block,
+#        so a kept invocation cannot be hidden inside a fake wrapper.
+#     2. Forward drift-guard: only two files under my/skills/ may contain a
+#        non-stamped `codex exec` at all — same anti-fake-stamp rules.
+#     3. The new skill mandates a LIVE Issue fetch before invoking the Judge.
+#     4. The new skill exists, is Codex-primary, and defers policy to
+#        c-bpm-sk-llm-selection.
+#     5. The OpenRouter key comes from user-level `~/.env`, never project-level.
+#     6. No GLM / DeepSeek / Kimi / Fable numeric version pin under my/.
+#     7. [#117] Both mandating files carry the network-enabled sandbox flags;
+#        `danger-full-access` is not sanctioned anywhere.
+#     8. No `model:` frontmatter key in any my/skills/*/SKILL.md (single-source
+#        model policy — repo-wide sweep of the 31 carriers ratified in #113;
+#        c-bpm-sk-question-auditor carries no key today and must stay key-free).
+#     9. [#112] c-bpm-sk-llm-selection carries the new ladder and the
+#        Producer/Judge role directive, and the stale bullets are gone.
+#
+#   SCOPE NOTE: my/commands/** call sites are deliberately OUT of scope here
+#   (sequenced to #118, after #112 lands); user-level CLAUDE.md ladder -> #119;
+#   command-side model keys -> #121.
+#
+#   SELF-MATCH NOTE: this file lives under tests/, outside my/, and the one
+#   repo-wide negative grep below excludes tests/ explicitly. The guard regexes
+#   in this file therefore never match the suite itself.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+
+LLM_SELECTION_REL="my/skills/c-bpm-sk-llm-selection/SKILL.md"
+DA_SKILL_REL="my/skills/c-bpm-sk-devils-advocate/SKILL.md"
+LLM_SELECTION="${REPO_ROOT}/${LLM_SELECTION_REL}"
+DA_SKILL="${REPO_ROOT}/${DA_SKILL_REL}"
+
+# ------------------------------------------------------------------
+# Enumerated call sites — binding rev-3 enumeration on Issue #113:
+# 14 SKILL.md + 3 reference files = 17 files. Each MUST end up with zero
+# `codex exec` AND a delegation reference to the new skill.
+#
+# The two lists are checked with different rules:
+#   * SKILL.md  — the stamped issue-comms block legitimately contains a
+#                 `codex exec` example, so it is stripped before counting;
+#                 in exchange the file must carry EXACTLY ONE stamped block
+#                 (a second, ad-hoc wrapper hiding a kept invocation fails).
+#   * reference — no legitimate stamped block exists, so the RAW file must
+#                 contain zero `codex exec` and zero stamp markers.
+# ------------------------------------------------------------------
+CALL_SITE_SKILLS=(
+  "my/skills/c-bpm-sk-linux-admin/SKILL.md"
+  "my/skills/c-bpm-sk-linux-audit/SKILL.md"
+  "my/skills/c-bpm-sk-milestone-type/SKILL.md"
+  "my/skills/c-bpm-sk-grill-claude-issue/SKILL.md"
+  "my/skills/c-bpm-sk-grill-me/SKILL.md"
+  "my/skills/c-bpm-sk-grill-me-issue/SKILL.md"
+  "my/skills/c-bpm-sk-auditor/SKILL.md"
+  "my/skills/c-bpm-sk-question-auditor/SKILL.md"
+  "my/skills/c-bpm-sk-idea-merge/SKILL.md"
+  "my/skills/c-bpm-sk-skill-creator/SKILL.md"
+  "my/skills/c-bpm-sk-skill-optimizer/SKILL.md"
+  "my/skills/c-bpm-sk-release-ops/SKILL.md"
+  "my/skills/c-bpm-sk-repo-scaffold/SKILL.md"
+  "my/skills/c-bpm-sk-linux-archive/SKILL.md"
+)
+
+CALL_SITE_REFERENCES=(
+  "my/skills/c-bpm-sk-auditor/references/codex-prompts.md"
+  "my/skills/c-bpm-sk-skill-optimizer/references/team-orchestration.md"
+  "my/skills/c-bpm-sk-flightphp-pro/references/team-orchestration.md"
+)
+
+# ------------------------------------------------------------------
+# Helper: print a file WITHOUT its stamped issue-comms block.
+# The awk pattern mirrors extract_block() in issue-comms-anchor.bats
+# (inverted) so both suites agree on the block boundaries. The master
+# block itself contains a `codex exec` example, so stripping it is
+# load-bearing for every codex-exec assertion below.
+# ------------------------------------------------------------------
+strip_stamped() {
+  awk '
+    /<!-- BEGIN issue-comms/ { p=1 }
+    !p { print }
+    /<!-- END issue-comms/   { p=0 }
+  ' "$1"
+}
+
+# ------------------------------------------------------------------
+# Helper: count `<!-- BEGIN issue-comms` markers in a file.
+# Anti-fake-stamp guard: strip_stamped() hides everything between ANY
+# BEGIN/END pair, so a kept `codex exec` could be smuggled past it inside
+# an ad-hoc second wrapper. A stamped SKILL.md has exactly one marker;
+# a reference file has none.
+# ------------------------------------------------------------------
+count_stamp_markers() {
+  grep -c -- '<!-- BEGIN issue-comms' "$1" || true
+}
+
+# ------------------------------------------------------------------
+# Helper: is the fetch-before-judging mandate stated as ONE coupled rule
+# on ONE line? The `[^.]` classes keep the whole match inside a single
+# sentence, so two unrelated sentences on adjacent lines cannot combine
+# into a false positive. Both phrasing orders are accepted:
+#   "Fetch the live Issue body and comments via gh api BEFORE invoking the Judge."
+#   "BEFORE invoking the Judge, fetch the live Issue body and comments."
+# ------------------------------------------------------------------
+_coupled_fetch_mandate() {
+  grep -qiE \
+    -e '(fetch|read|pull|retrieve)[^.]{0,80}issue[^.]{0,80}before[^.]{0,40}(invok|judg|codex)' \
+    -e 'before[^.]{0,40}(invok|judg|codex)[^.]{0,80}(fetch|read|pull|retrieve)[^.]{0,80}issue' \
+    "$1"
+}
+
+# ------------------------------------------------------------------
+# Helper: assert a file contains every needle (case-insensitive fixed
+# string). Reports all missing needles. Missing file = clean failure.
+# ------------------------------------------------------------------
+_assert_needles() {
+  local rel="$1"; shift
+  local f="${REPO_ROOT}/${rel}"
+  if [[ ! -f "${f}" ]]; then
+    printf 'Required file not found: %s\n' "${rel}" >&2
+    return 1
+  fi
+  local missing=()
+  local needle
+  for needle in "$@"; do
+    if ! grep -qiF -- "${needle}" "${f}"; then
+      missing+=("${needle}")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    printf 'Missing required content in %s:\n' "${rel}" >&2
+    printf '  %s\n' "${missing[@]}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# Helper: assert a file does NOT contain any of the given fixed strings.
+# ------------------------------------------------------------------
+_assert_absent_needles() {
+  local rel="$1"; shift
+  local f="${REPO_ROOT}/${rel}"
+  if [[ ! -f "${f}" ]]; then
+    printf 'Required file not found: %s\n' "${rel}" >&2
+    return 1
+  fi
+  local present=()
+  local needle
+  for needle in "$@"; do
+    if grep -qiF -- "${needle}" "${f}"; then
+      present+=("${needle}")
+    fi
+  done
+  if (( ${#present[@]} > 0 )); then
+    printf 'Stale wording still present in %s:\n' "${rel}" >&2
+    printf '  %s\n' "${present[@]}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 1 - enumerated call sites: invocation REMOVED + delegation added
+# ==================================================================
+
+@test "all 17 enumerated call-site files have their direct 'codex exec' removed and delegate to c-bpm-sk-devils-advocate" {
+  local offenders=()
+  local rel f n m
+
+  # --- 14 SKILL.md files: strip the ONE legitimate stamped block ---
+  for rel in "${CALL_SITE_SKILLS[@]}"; do
+    f="${REPO_ROOT}/${rel}"
+    if [[ ! -f "${f}" ]]; then
+      offenders+=("${rel}: file not found")
+      continue
+    fi
+    # (a) exactly one stamped block — no ad-hoc wrapper to hide code in
+    m="$(count_stamp_markers "${f}")"
+    if (( m != 1 )); then
+      offenders+=("${rel}: ${m} '<!-- BEGIN issue-comms' marker(s), expected exactly 1 (fake stamp block?)")
+    fi
+    # (b) no direct invocation left outside the stamped issue-comms block
+    n="$(strip_stamped "${f}" | grep -c -- 'codex exec' || true)"
+    if (( n > 0 )); then
+      offenders+=("${rel}: ${n} non-stamped 'codex exec' occurrence(s) still present (must be 0)")
+    fi
+    # (c) delegation reference to the canonical Judge-invocation skill
+    if ! grep -qF -- 'c-bpm-sk-devils-advocate' "${f}"; then
+      offenders+=("${rel}: missing delegation reference to c-bpm-sk-devils-advocate")
+    fi
+  done
+
+  # --- 3 reference files: RAW content, no stripping, no stamp markers ---
+  for rel in "${CALL_SITE_REFERENCES[@]}"; do
+    f="${REPO_ROOT}/${rel}"
+    if [[ ! -f "${f}" ]]; then
+      offenders+=("${rel}: file not found")
+      continue
+    fi
+    n="$(grep -c -- 'codex exec' "${f}" || true)"
+    if (( n > 0 )); then
+      offenders+=("${rel}: ${n} raw 'codex exec' occurrence(s) still present (must be 0; reference files have no stamped block)")
+    fi
+    m="$(count_stamp_markers "${f}")"
+    if (( m != 0 )); then
+      offenders+=("${rel}: ${m} '<!-- BEGIN issue-comms' marker(s), expected 0 (reference files are not stamped)")
+    fi
+    if ! grep -qF -- 'c-bpm-sk-devils-advocate' "${f}"; then
+      offenders+=("${rel}: missing delegation reference to c-bpm-sk-devils-advocate")
+    fi
+  done
+  if (( ${#offenders[@]} > 0 )); then
+    printf 'Issue #113 call-site routing incomplete (%d finding(s)):\n' "${#offenders[@]}" >&2
+    printf '  %s\n' "${offenders[@]}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 2 - exclusivity / forward drift-guard across my/skills/
+# ==================================================================
+
+@test "only c-bpm-sk-llm-selection and c-bpm-sk-devils-advocate may contain a non-stamped 'codex exec' under my/skills/" {
+  local offenders=()
+  local f rel n m is_skill
+  # my/commands/** is out of scope here (sequenced to #118).
+  while IFS= read -r f; do
+    rel="${f#${REPO_ROOT}/}"
+    is_skill=0
+    if [[ "${rel}" == my/skills/c-bpm-sk-*/SKILL.md ]]; then
+      is_skill=1
+    fi
+
+    # Anti-fake-stamp guard applies to EVERY file, including the two
+    # allowed invocation sites: SKILL.md carries exactly one stamped
+    # block, any other .md carries none.
+    m="$(count_stamp_markers "${f}")"
+    if (( is_skill == 1 )); then
+      (( m == 1 )) || offenders+=("${rel}: ${m} '<!-- BEGIN issue-comms' marker(s), expected exactly 1 (fake stamp block?)")
+    else
+      (( m == 0 )) || offenders+=("${rel}: ${m} '<!-- BEGIN issue-comms' marker(s), expected 0 (only SKILL.md is stamped)")
+    fi
+
+    # The two sanctioned invocation sites are exempt from the codex-exec
+    # count (but not from the stamp-marker check above).
+    if [[ "${rel}" == "${LLM_SELECTION_REL}" || "${rel}" == "${DA_SKILL_REL}" ]]; then
+      continue
+    fi
+
+    if (( is_skill == 1 )); then
+      n="$(strip_stamped "${f}" | grep -c -- 'codex exec' || true)"
+      (( n == 0 )) || offenders+=("${rel}: ${n} non-stamped 'codex exec' occurrence(s)")
+    else
+      n="$(grep -c -- 'codex exec' "${f}" || true)"
+      (( n == 0 )) || offenders+=("${rel}: ${n} raw 'codex exec' occurrence(s)")
+    fi
+  done < <(find "${REPO_ROOT}/my/skills" -type f -name '*.md' | sort)
+
+  if (( ${#offenders[@]} > 0 )); then
+    printf 'Codex invocation must live in exactly two files (%s, %s).\n' \
+      "${LLM_SELECTION_REL}" "${DA_SKILL_REL}" >&2
+    printf 'Unexpected invocation site(s):\n' >&2
+    printf '  %s\n' "${offenders[@]}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 3 - the new skill mandates a LIVE Issue fetch before judging
+# ==================================================================
+
+@test "c-bpm-sk-devils-advocate mandates a live Issue fetch (body + comments) before invoking the Judge" {
+  if [[ ! -f "${DA_SKILL}" ]]; then
+    printf 'Skill not found: %s\n' "${DA_SKILL_REL}" >&2
+    return 1
+  fi
+
+  # PRIMARY: the mandate must be stated as ONE coupled rule — fetch the
+  # live Issue BEFORE the Judge/Codex is invoked — not as two unrelated
+  # narrative fragments.
+  if ! _coupled_fetch_mandate "${DA_SKILL}"; then
+    printf 'No coupled fetch-before-judging mandate found in %s\n' "${DA_SKILL_REL}" >&2
+    printf 'Expected ONE line (one sentence) stating: fetch/retrieve/read the Issue BEFORE invoking the Judge/Codex.\n' >&2
+    return 1
+  fi
+
+  # SECONDARY: the mechanics and the failure behaviour.
+  _assert_needles "${DA_SKILL_REL}" \
+    "Live Issue Fetch" \
+    "gh api repos/" \
+    "/comments" \
+    "before invoking the Judge" \
+    "Judge unable"
+
+  # The payload must be Issue-sourced, never an authored side-car .md.
+  if ! grep -qiE 'never.{0,60}(authored|side.?car|hand.?written).{0,20}\.md' "${DA_SKILL}"; then
+    printf 'Missing the "payload is Issue-sourced, never an authored .md" rule in %s\n' "${DA_SKILL_REL}" >&2
+    return 1
+  fi
+  # A fabricated verdict is never acceptable when the fetch fails.
+  if ! grep -qiE '(never|no|not).{0,120}fabricat' "${DA_SKILL}"; then
+    printf 'Missing the "never a fabricated verdict" rule in %s\n' "${DA_SKILL_REL}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 4 - the skill exists, is Codex-primary, defers policy upstream
+# ==================================================================
+
+@test "c-bpm-sk-devils-advocate exists, is Codex-primary, and references c-bpm-sk-llm-selection" {
+  if [[ ! -f "${DA_SKILL}" ]]; then
+    printf 'Skill not found: %s\n' "${DA_SKILL_REL}" >&2
+    return 1
+  fi
+  _assert_needles "${DA_SKILL_REL}" \
+    "codex exec --skip-git-repo-check" \
+    "Codex" \
+    "primary" \
+    "c-bpm-sk-llm-selection" \
+    "cac pull --tool codex"
+}
+
+# ==================================================================
+# Test 5 - OpenRouter key from user-level ~/.env, never project-level
+# ==================================================================
+
+@test "OpenRouter key is sourced from user-level ~/.env only, never project-level" {
+  local rel
+  for rel in "${LLM_SELECTION_REL}" "${DA_SKILL_REL}"; do
+    _assert_needles "${rel}" "~/.env"
+  done
+  # The single source must state the never-project-level rule explicitly.
+  if ! grep -qiE 'never.{0,40}project.?level' "${LLM_SELECTION}"; then
+    printf 'Missing the "never project-level .env" rule in %s\n' "${LLM_SELECTION_REL}" >&2
+    return 1
+  fi
+  # And neither file may point at a project-local .env path.
+  local offenders=() f hits
+  for rel in "${LLM_SELECTION_REL}" "${DA_SKILL_REL}"; do
+    f="${REPO_ROOT}/${rel}"
+    [[ -f "${f}" ]] || continue
+    hits="$(grep -nE '(\./\.env|\$\{?PWD\}?/\.env)' "${f}" || true)"
+    if [[ -n "${hits}" ]]; then
+      offenders+=("${rel}: ${hits}")
+    fi
+  done
+  if (( ${#offenders[@]} > 0 )); then
+    printf 'Project-level .env reference found (key must come from ~/.env):\n' >&2
+    printf '  %s\n' "${offenders[@]}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 6 - no GLM / DeepSeek / Kimi / Fable numeric version pin under my/
+# ==================================================================
+
+@test "no GLM / DeepSeek / Kimi / Fable numeric version pin anywhere under my/" {
+  cd "${REPO_ROOT}"
+  local bad
+  # Slugs are resolved at invocation time via /api/v1/models; families are
+  # named by role, never pinned numerically (single-source model policy, #98).
+  bad="$(grep -rniE -- '(glm|deepseek|kimi|fable)[-_ ]?v?[0-9]' my/ || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'Hard-wired model version pin found under my/:\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 7 - [#117] network-enabled sandbox flags; danger-full-access banned
+# ==================================================================
+
+@test "[#117] both mandating files carry the network-enabled sandbox flags and 'danger-full-access' is nowhere sanctioned" {
+  local rel
+  for rel in "${LLM_SELECTION_REL}" "${DA_SKILL_REL}"; do
+    _assert_needles "${rel}" \
+      "-s workspace-write" \
+      "sandbox_workspace_write.network_access=true"
+  done
+
+  # The FULL canonical command must appear contiguously — tokens scattered
+  # through prose do not prove the invocation actually carries them. Token
+  # order is load-bearing: c-bpm-sk-codex-flag.bats requires a contiguous
+  # `codex exec --skip-git-repo-check`, so the sandbox flags come AFTER it.
+  local canonical='codex exec --skip-git-repo-check -s workspace-write -c sandbox_workspace_write.network_access=true'
+  local offenders=() f
+  for rel in "${LLM_SELECTION_REL}" "${DA_SKILL_REL}"; do
+    f="${REPO_ROOT}/${rel}"
+    if [[ ! -f "${f}" ]]; then
+      offenders+=("${rel}: file not found")
+      continue
+    fi
+    if ! grep -qF -- "${canonical}" "${f}"; then
+      offenders+=("${rel}: missing contiguous canonical command '${canonical}'")
+    fi
+  done
+  if (( ${#offenders[@]} > 0 )); then
+    printf 'Canonical invocation token order broken:\n' >&2
+    printf '  %s\n' "${offenders[@]}" >&2
+    return 1
+  fi
+
+  # Repo-wide negative. tests/ is excluded so this suite does not match
+  # its own guard string; .git and node_modules are noise. Lines that
+  # FORBID the flag ("not sanctioned", "never", "forbidden", "banned") are
+  # legitimate policy prose — the plan requires such a line in the skill —
+  # so they are filtered out before failing.
+  cd "${REPO_ROOT}"
+  local bad
+  bad="$(grep -rn --exclude-dir=.git --exclude-dir=tests --exclude-dir=node_modules \
+    -- 'danger-full-access' . \
+    | grep -viE 'not sanctioned|never|forbidden|banned' || true)"
+  if [[ -n "${bad}" ]]; then
+    printf 'danger-full-access is NOT sanctioned (workspace-write is the ceiling per #117):\n%s\n' "${bad}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 8 - no `model:` frontmatter key in any my/skills/*/SKILL.md
+# ==================================================================
+
+@test "no 'model:' key in the frontmatter of any my/skills/*/SKILL.md (single-source model policy)" {
+  local offenders=()
+  local f rel hit
+  shopt -s nullglob
+  local targets=( "${REPO_ROOT}"/my/skills/c-bpm-sk-*/SKILL.md )
+  if (( ${#targets[@]} == 0 )); then
+    printf 'No skill SKILL.md files found under my/skills/ — enumeration broken.\n' >&2
+    return 1
+  fi
+  for f in "${targets[@]}"; do
+    rel="${f#${REPO_ROOT}/}"
+    # Frontmatter only: the first --- ... --- block. Template examples
+    # inside fenced code blocks further down the body are not frontmatter.
+    hit="$(awk '
+      NR==1 && $0=="---" { inFm=1; next }
+      inFm && $0=="---"  { exit }
+      inFm               { print }
+    ' "${f}" | grep -nE '^model:[[:space:]]*' || true)"
+    if [[ -n "${hit}" ]]; then
+      offenders+=("${rel}: ${hit}")
+    fi
+  done
+  if (( ${#offenders[@]} > 0 )); then
+    printf 'Frontmatter model: key found — forbidden in EVERY my/skills SKILL.md (incl. %s).\n' "${LLM_SELECTION_REL}" >&2
+    printf 'Model policy lives as PROSE in c-bpm-sk-llm-selection; no file pins a model in frontmatter:\n' >&2
+    printf '  %s\n' "${offenders[@]}" >&2
+    return 1
+  fi
+}
+
+# ==================================================================
+# Test 9 - [#112] llm-selection ladder + role-directive wording
+# ==================================================================
+
+@test "[#112] c-bpm-sk-llm-selection carries the new fallback ladder and the Producer/Judge role directive" {
+  _assert_needles "${LLM_SELECTION_REL}" \
+    "OPENROUTER_API_KEY" \
+    "c-bpm-sk-devils-advocate"
+
+  # Ladder: OpenRouter is the FIRST substitute-Judge tier after Codex.
+  # Both the Unicode arrow and the ASCII variant are accepted.
+  if ! grep -qiE 'Codex[[:space:]]*(→|->)[[:space:]]*OpenRouter' "${LLM_SELECTION}"; then
+    printf 'Missing fallback-ladder wording "Codex -> OpenRouter" (→ or ->) in %s\n' "${LLM_SELECTION_REL}" >&2
+    return 1
+  fi
+
+  # Role directive: Fable is the default Producer/teammate model.
+  if ! grep -qiE 'fable.{0,80}(default|producer|teammate)' "${LLM_SELECTION}"; then
+    printf 'Missing role directive "Fable = default Producer/teammate model" in %s\n' "${LLM_SELECTION_REL}" >&2
+    return 1
+  fi
+  # Opus only where Fable is not a fit.
+  if ! grep -qiE 'opus.{0,80}(not a fit|only where|only when)' "${LLM_SELECTION}"; then
+    printf 'Missing role directive "Opus only where Fable is not a fit" in %s\n' "${LLM_SELECTION_REL}" >&2
+    return 1
+  fi
+  # Codex remains the Judge.
+  if ! grep -qiE 'codex.{0,60}judge' "${LLM_SELECTION}"; then
+    printf 'Missing role directive "Codex remains the Judge" in %s\n' "${LLM_SELECTION_REL}" >&2
+    return 1
+  fi
+
+  # Stale bullets that the role directive REPLACES must be gone.
+  _assert_absent_needles "${LLM_SELECTION_REL}" \
+    "always the newest Opus" \
+    "for cross-model validation only" \
+    "not yet adopted"
+}

--- a/tests/bash/readme-guards.bats
+++ b/tests/bash/readme-guards.bats
@@ -1,0 +1,222 @@
+#!/usr/bin/env bats
+#
+# readme-guards.bats — drift guards for README.md (Issue #123)
+# Run with: bats tests/bash/readme-guards.bats
+#
+# The README is the entry point a new machine reads before it has any local
+# context. Issue #123 replaced a stale hand-maintained inventory (a 145-line
+# Mermaid graph claiming 27 skills / 8 commands against a repo that had 33/9,
+# plus German prose and unverified flags) with a short operational README.
+# These guards keep it honest: every referenced item and flag must exist, no
+# model version may be pinned (Issue #98), links must open in a new tab, the
+# prose must be English, and the facts the install path depends on must stay.
+#
+#   NOTE: the model-pin regex below intentionally spells out "gpt-5"/"opus-4".
+#   This file lives under tests/ (outside my/), so it does not trip the
+#   acceptance grep `grep -rn 'gpt-5' my/ = 0` from Issue #98.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../.." && pwd)"
+README="${REPO_ROOT}/README.md"
+
+# Emit the README with fenced code blocks removed (prose only).
+readme_prose() {
+  awk '/^[[:space:]]*```/ { f = !f; next } !f' "${README}"
+}
+
+# Emit only the lines inside fenced code blocks.
+readme_fences() {
+  awk '/^[[:space:]]*```/ { f = !f; next } f' "${README}"
+}
+
+# ------------------------------------------------------------------
+# 1: the six required top-level sections exist
+# ------------------------------------------------------------------
+
+@test "README has the six required top-level sections" {
+  [ -f "${README}" ] || { printf 'README.md not found at %s\n' "${README}" >&2; return 1; }
+  local missing=0 h
+  for h in \
+    '## 1. What This Is' \
+    '## 2. Installation' \
+    '## 3. How the Agent Teams Work' \
+    '## 4. Model Policy' \
+    '## 5. Testing' \
+    '## 6. Key Commands'
+  do
+    if ! grep -qF -- "${h}" "${README}"; then
+      printf 'Missing required README section heading: %s\n' "${h}" >&2
+      missing=1
+    fi
+  done
+  return "${missing}"
+}
+
+# ------------------------------------------------------------------
+# 2: every c-bpm-* item the README names actually exists
+#    (parses the README's own backtick tokens, so future additions are
+#     guarded too — no hardcoded inventory to go stale)
+# ------------------------------------------------------------------
+
+@test "every c-bpm-* item referenced in README exists on disk" {
+  local bad=0 tok
+  # Every c-bpm token the README names, de-duplicated. A `.bats` suffix means
+  # the reference is to a test file, not to the item itself.
+  for tok in $(grep -oE 'c-bpm-(sk|cm|ag|rb)-[a-z0-9-]+(\.bats)?' "${README}" | sed 's/-*$//' | sort -u); do
+    case "${tok}" in
+      *.bats)
+        [ -f "${REPO_ROOT}/tests/bash/${tok}" ] || {
+          printf 'README references test %s but tests/bash/%s does not exist\n' "${tok}" "${tok}" >&2; bad=1; }
+        ;;
+      c-bpm-sk-*)
+        [ -f "${REPO_ROOT}/my/skills/${tok}/SKILL.md" ] || {
+          printf 'README references skill %s but my/skills/%s/SKILL.md does not exist\n' "${tok}" "${tok}" >&2; bad=1; }
+        ;;
+      c-bpm-cm-*)
+        # A command may be a slash-command file, a root CLI script, or both.
+        if [ ! -f "${REPO_ROOT}/my/commands/${tok}.md" ] && [ ! -f "${REPO_ROOT}/${tok}" ]; then
+          printf 'README references command %s but neither my/commands/%s.md nor ./%s exists\n' "${tok}" "${tok}" "${tok}" >&2
+          bad=1
+        fi
+        ;;
+      c-bpm-ag-*)
+        [ -f "${REPO_ROOT}/my/agents/${tok}.md" ] || {
+          printf 'README references agent %s but my/agents/%s.md does not exist\n' "${tok}" "${tok}" >&2; bad=1; }
+        ;;
+      c-bpm-rb-*)
+        [ -f "${REPO_ROOT}/my/runbooks/${tok}.md" ] || {
+          printf 'README references runbook %s but my/runbooks/%s.md does not exist\n' "${tok}" "${tok}" >&2; bad=1; }
+        ;;
+    esac
+  done
+  return "${bad}"
+}
+
+@test "every root CLI referenced in README exists and is executable" {
+  local bad=0 cli
+  for cli in bcgasl install install-hooks sync; do
+    if grep -qE "(^|[^a-z-])${cli}([^a-z-]|$)" "${README}"; then
+      [ -x "${REPO_ROOT}/${cli}" ] || {
+        printf 'README references ./%s but it is missing or not executable\n' "${cli}" >&2; bad=1; }
+    fi
+  done
+  return "${bad}"
+}
+
+# ------------------------------------------------------------------
+# 3: every documented flag exists in the script it is documented for
+# ------------------------------------------------------------------
+
+@test "every --flag documented in a README code fence exists in its script" {
+  local bad=0
+  while IFS= read -r line; do
+    local owner="" tok base flag
+    line="${line%%#*}"   # inline comments name tools they do not invoke
+    # Owner = first token on the line whose basename names a repo-root script
+    # (covers ./script, sudo ./script, and curl <url>/script | bash).
+    for tok in ${line}; do
+      base="${tok##*/}"
+      base="${base%\"}"; base="${base%\'}"; base="${base%;}"
+      [ -n "${base}" ] || continue
+      if [ -z "${owner}" ] && [ -f "${REPO_ROOT}/${base}" ]; then owner="${base}"; fi
+    done
+    [ -n "${owner}" ] || continue
+    for tok in ${line}; do
+      case "${tok}" in
+        --[a-z]*)
+          flag="${tok%%=*}"
+          if ! grep -qF -- "${flag}" "${REPO_ROOT}/${owner}"; then
+            printf 'README documents %s for ./%s but that flag is not in the script\n' "${flag}" "${owner}" >&2
+            bad=1
+          fi
+          ;;
+      esac
+    done
+  done < <(readme_fences)
+  return "${bad}"
+}
+
+# ------------------------------------------------------------------
+# 4: no model version pin (Issue #98 single-source model policy)
+# ------------------------------------------------------------------
+
+@test "README pins no model version (single-source model policy, #98)" {
+  local hits
+  hits="$(grep -nEi -- '(gpt-[0-9]|opus[- ][0-9]|sonnet[- ][0-9]|haiku[- ][0-9]|claude-[0-9]|gemini[- ][0-9])' "${README}" || true)"
+  if [ -n "${hits}" ]; then
+    printf 'README pins a model version (forbidden by #98 — point at c-bpm-sk-llm-selection instead):\n%s\n' "${hits}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 5: external links open in a new tab, and use HTML not Markdown
+# ------------------------------------------------------------------
+
+@test "every external href carries target=\"_blank\" and no Markdown http links in prose" {
+  local bad=0 hits
+  hits="$(grep -oE '<a [^>]*href="https?://[^>]*>' "${README}" | grep -v 'target="_blank"' || true)"
+  if [ -n "${hits}" ]; then
+    printf 'External anchor(s) without target="_blank":\n%s\n' "${hits}" >&2
+    bad=1
+  fi
+  hits="$(readme_prose | grep -nE '\]\(https?://' || true)"
+  if [ -n "${hits}" ]; then
+    printf 'Markdown-style external link(s) outside code fences (must be <a href=... target="_blank">):\n%s\n' "${hits}" >&2
+    bad=1
+  fi
+  return "${bad}"
+}
+
+# ------------------------------------------------------------------
+# 6: English only
+# ------------------------------------------------------------------
+
+@test "README prose is English only" {
+  local hits
+  hits="$(grep -nE -- '(Maschine|Komplettes|geklont|Aktualisiert|Vorschau|Änderungen|Typischer|Nur Standard|Ohne Repo|Danach stehen|anlegen|z\.B\.)' "${README}" || true)"
+  if [ -n "${hits}" ]; then
+    printf 'German prose found in README (English only, per global rules):\n%s\n' "${hits}" >&2
+    return 1
+  fi
+}
+
+# ------------------------------------------------------------------
+# 7: mandatory facts the install + operate path depends on
+# ------------------------------------------------------------------
+
+@test "README states the mandatory install/operate facts" {
+  local bad=0
+  _fact() { # <description> <grep-mode-args...>
+    local desc="$1"; shift
+    if ! grep -q "$@" "${README}"; then
+      printf 'README is missing a mandatory fact: %s\n' "${desc}" >&2
+      bad=1
+    fi
+  }
+
+  # Hook install — both settings paths, with the amended "only if present" caveat (#65/#76).
+  _fact 'the ~/.claude/settings.json path'                 -F -- '~/.claude/settings.json'
+  _fact 'the ~/.config/claude/settings.json path'          -F -- '~/.config/claude/settings.json'
+  _fact 'the "where they exist" caveat for settings files' -F -- 'where they exist'
+  _fact 'the "skipped, not created" caveat'                -F -- 'skipped, not created'
+  _fact 'the #65/#76 pointer for the settings-path gap'    -E -- '#65|#76'
+  _fact 'the install-hooks step'                           -F -- 'install-hooks'
+
+  # Update path (user requirement, 2026-07-25) — drift rationale is #114.
+  _fact 'the "Updating an existing installation" subsection' -F -- '### Updating an existing installation'
+  _fact 'the installed-copy drift pointer (#114)'            -F -- '#114'
+
+  # Team operation.
+  _fact 'DONE is human-only'                               -E -- 'DONE.*human|[Hh]uman.*DONE'
+  _fact 'the Codex/Judge gate skill pointer'               -F -- 'c-bpm-sk-devils-advocate'
+  _fact 'the teammate-lifecycle policy pointer (#120)'     -F -- '#120'
+
+  # Model policy + testing honesty.
+  _fact 'the model policy pointer'                         -F -- 'c-bpm-sk-llm-selection'
+  _fact 'the known-red write-gate note (#100)'             -F -- '#100'
+  _fact 'the E2E harness pointer (#122)'                   -F -- '#122'
+
+  return "${bad}"
+}


### PR DESCRIPTION
## Summary
- **#113** — NEW `c-bpm-sk-devils-advocate`: the canonical Judge skill (Codex primary with network-enabled sanitized sandbox invocation per #117, live-Issue fetch before judging, cac-pull recovery, OpenRouter cheap-frontier fallback with user-level `~/.env` credentials, documented-blocked failure behavior). `c-bpm-sk-llm-selection` becomes the single policy source (OpenRouter fallback tier, updated Judge ladder, Fable-default-Producer role directive). 17 call-site files routed through the new skill; `model:` frontmatter key removed from all 31 carriers (#98).
- **#112** — NEW `/c-bpm-cm-goal-issue`: autonomous, unattended overnight run over in-scope issues (default: milestone `new`), batching via `/c-bpm-cm-openissues-team`, per-issue direct-to-main commits at `test-approved`, DONE human-only, documented-blocked stall guard, SUMMARY morning report with ratified precedence block.
- 2 new bats suites (23 tests): enumerated call-site removal proof, exclusivity drift-guard, fake-stamp detection, SUMMARY-precedence coupling, no-model-key locks.

## Review trail
All three Codex gates per issue (plan, test design, verification) passed — full verdicts as comments on #113 and #112. Both issues are at milestone **test-approved**; DONE remains human.

## Test state
Full suite: 166 tests, 157 green; the 9 red are the pre-existing #100 issue-write-gate fixtures (unrelated, tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)